### PR TITLE
Multi-model support, BS-RoFormer, HuggingFace auto-download, Spectrogram node

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,171 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor, any work of
+      authorship, including the original version of the Work and any
+      modifications or additions to that Work or Derivative Works of the Work,
+      by the individual or entity submitting the work to the Licensor.
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any
+      Contribution embodied within the Work constitutes direct or
+      contributory patent infringement, then any patent licenses granted to
+      You under this License for that Work shall terminate as of the date
+      such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the Work
+      or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You meet
+      the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative Works
+          a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works that
+          You distribute, all copyright, patent, trademark, and attribution
+          notices from the Source form of the Work, excluding those notices
+          that do not pertain to any part of the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the attribution
+          notices contained within such NOTICE file, in at least one of the
+          following places: within a NOTICE text provided as part of the
+          Derivative Works; within the Source form or documentation, if
+          provided along with the Derivative Works; or, within a display
+          generated by the Derivative Works, if and wherever such third-party
+          notices normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License. You may
+          add Your own attribution notices within Derivative Works that You
+          distribute, alongside or in addition to the NOTICE text from the
+          Work, provided that such additional attribution notices cannot be
+          construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Derivative Works, and to permit persons to whom the Derivative Works
+      is furnished to do so, subject to the following conditions.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a result
+      of this License or out of the use or inability to use the Work
+      (including but not limited to damages for loss of goodwill, work
+      stoppage, computer failure or malfunction, or all other commercial
+      damages or losses), even if such Contributor has been advised of the
+      possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer, and
+      charge a fee for, acceptance of support, warranty, indemnity, or
+      other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer only
+      conditions consistent with this License.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024-2025 Ethanfel
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,11 @@
+import os
+import folder_paths
+
+# Register a dedicated subfolder: ComfyUI/models/MelBandRoFormer/
+_model_dir = os.path.join(folder_paths.models_dir, "MelBandRoFormer")
+os.makedirs(_model_dir, exist_ok=True)
+folder_paths.add_model_folder_path("MelBandRoFormer", _model_dir)
+
 from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/example_workflows/melband_example.json
+++ b/example_workflows/melband_example.json
@@ -1,19 +1,164 @@
 {
   "id": "8b7a9a57-2303-4ef5-9fc2-bf41713bd1fc",
   "revision": 0,
-  "last_node_id": 326,
-  "last_link_id": 585,
+  "last_node_id": 334,
+  "last_link_id": 606,
   "nodes": [
     {
-      "id": 325,
-      "type": "MelBandRoFormerModelLoader",
+      "id": 331,
+      "type": "PreviewImage",
       "pos": [
-        2141.159423828125,
-        -1714.64501953125
+        3328,
+        -1536
       ],
       "size": [
-        419.69976806640625,
-        58
+        416,
+        320
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 597
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1",
+        "Node name for S&R": "PreviewImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 334,
+      "type": "MelBandRoFormerSampler",
+      "pos": [
+        2528,
+        -1824
+      ],
+      "size": [
+        256,
+        160
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MELROFORMERMODEL",
+          "link": 601
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 602
+        }
+      ],
+      "outputs": [
+        {
+          "name": "stem_1",
+          "type": "AUDIO",
+          "links": [
+            603,
+            604
+          ]
+        },
+        {
+          "name": "stem_2",
+          "type": "AUDIO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "aux_id": "ethanfel/ComfyUI-MelBandRoFormer",
+        "ver": "f9743681bb0078851697c386595108c8503c3218",
+        "Node name for S&R": "MelBandRoFormerSampler",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        8,
+        2,
+        0.1,
+        8
+      ]
+    },
+    {
+      "id": 332,
+      "type": "MelBandRoFormerSpectrogram",
+      "pos": [
+        2816,
+        -1536
+      ],
+      "size": [
+        352,
+        192
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio_a",
+          "type": "AUDIO",
+          "link": 599
+        },
+        {
+          "name": "audio_b",
+          "type": "AUDIO",
+          "link": 604
+        }
+      ],
+      "outputs": [
+        {
+          "name": "spectrogram",
+          "type": "IMAGE",
+          "links": [
+            597
+          ]
+        }
+      ],
+      "properties": {
+        "aux_id": "ethanfel/ComfyUI-MelBandRoFormer",
+        "ver": "f9743681bb0078851697c386595108c8503c3218",
+        "Node name for S&R": "MelBandRoFormerSpectrogram",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "Original",
+        "Mel-Band",
+        "stacked + difference",
+        512,
+        512
+      ]
+    },
+    {
+      "id": 329,
+      "type": "MelBandRoFormerModelLoaderLatest",
+      "pos": [
+        2016,
+        -1824
+      ],
+      "size": [
+        384,
+        96
       ],
       "flags": {},
       "order": 0,
@@ -24,29 +169,69 @@
           "name": "model",
           "type": "MELROFORMERMODEL",
           "links": [
-            581
+            601
           ]
         }
       ],
       "properties": {
-        "aux_id": "kijai/ComfyUI-MelBandRoFormer",
-        "ver": "7b12f8c6105666552ac4e4f08b73e0f96eb05c64",
-        "Node name for S&R": "MelBandRoFormerModelLoader"
+        "aux_id": "ethanfel/ComfyUI-MelBandRoFormer",
+        "ver": "07b88cbc988a019050b635af2e932958bb71fa57",
+        "Node name for S&R": "MelBandRoFormerModelLoaderLatest",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
       },
       "widgets_values": [
-        "MelRoFormer\\MelBandRoformer_fp16.safetensors"
+        "Denoise · aufr33 ⭐",
+        false
       ]
     },
     {
-      "id": 317,
-      "type": "LoadAudio",
+      "id": 319,
+      "type": "PreviewAudio",
       "pos": [
-        2146.195068359375,
-        -1579.27783203125
+        3328,
+        -1856
       ],
       "size": [
-        274.080078125,
-        136
+        384,
+        96
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 603
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.51",
+        "Node name for S&R": "PreviewAudio",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 333,
+      "type": "LoadAudio",
+      "pos": [
+        2112,
+        -1664
+      ],
+      "size": [
+        288,
+        160
       ],
       "flags": {},
       "order": 1,
@@ -57,31 +242,38 @@
           "name": "AUDIO",
           "type": "AUDIO",
           "links": [
-            582
+            599,
+            602,
+            606
           ]
         }
       ],
       "properties": {
         "cnr_id": "comfy-core",
-        "ver": "0.3.51",
-        "Node name for S&R": "LoadAudio"
+        "ver": "0.18.1",
+        "Node name for S&R": "LoadAudio",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
       },
       "widgets_values": [
-        "0321. Alphaville - Big In Japan.mp3",
+        "2.mp4",
         null,
         null
       ]
     },
     {
-      "id": 319,
+      "id": 323,
       "type": "PreviewAudio",
       "pos": [
-        2892.392578125,
-        -1695.0682373046875
+        3328,
+        -1696
       ],
       "size": [
-        383.5520935058594,
-        88
+        384,
+        96
       ],
       "flags": {},
       "order": 3,
@@ -90,124 +282,76 @@
         {
           "name": "audio",
           "type": "AUDIO",
-          "link": 583
+          "link": 606
         }
       ],
       "outputs": [],
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.3.51",
-        "Node name for S&R": "PreviewAudio"
-      },
-      "widgets_values": []
-    },
-    {
-      "id": 326,
-      "type": "MelBandRoFormerSampler",
-      "pos": [
-        2610.4697265625,
-        -1629.0616455078125
-      ],
-      "size": [
-        222.73397827148438,
-        46
-      ],
-      "flags": {},
-      "order": 2,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "model",
-          "type": "MELROFORMERMODEL",
-          "link": 581
-        },
-        {
-          "name": "audio",
-          "type": "AUDIO",
-          "link": 582
+        "Node name for S&R": "PreviewAudio",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
         }
-      ],
-      "outputs": [
-        {
-          "name": "vocals",
-          "type": "AUDIO",
-          "links": [
-            583
-          ]
-        },
-        {
-          "name": "instruments",
-          "type": "AUDIO",
-          "links": [
-            585
-          ]
-        }
-      ],
-      "properties": {
-        "aux_id": "kijai/ComfyUI-MelBandRoFormer",
-        "ver": "7b12f8c6105666552ac4e4f08b73e0f96eb05c64",
-        "Node name for S&R": "MelBandRoFormerSampler"
-      }
-    },
-    {
-      "id": 323,
-      "type": "PreviewAudio",
-      "pos": [
-        2897.984619140625,
-        -1545.7156982421875
-      ],
-      "size": [
-        376.83953857421875,
-        91.35621643066406
-      ],
-      "flags": {},
-      "order": 4,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "audio",
-          "type": "AUDIO",
-          "link": 585
-        }
-      ],
-      "outputs": [],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.3.51",
-        "Node name for S&R": "PreviewAudio"
       },
       "widgets_values": []
     }
   ],
   "links": [
     [
-      581,
-      325,
+      597,
+      332,
       0,
-      326,
+      331,
+      0,
+      "IMAGE"
+    ],
+    [
+      599,
+      333,
+      0,
+      332,
+      0,
+      "AUDIO"
+    ],
+    [
+      601,
+      329,
+      0,
+      334,
       0,
       "MELROFORMERMODEL"
     ],
     [
-      582,
-      317,
+      602,
+      333,
       0,
-      326,
+      334,
       1,
       "AUDIO"
     ],
     [
-      583,
-      326,
+      603,
+      334,
       0,
       319,
       0,
       "AUDIO"
     ],
     [
-      585,
-      326,
+      604,
+      334,
+      0,
+      332,
       1,
+      "AUDIO"
+    ],
+    [
+      606,
+      333,
+      0,
       323,
       0,
       "AUDIO"
@@ -217,13 +361,13 @@
   "config": {},
   "extra": {
     "ds": {
-      "scale": 1.1918176537728358,
+      "scale": 1.2380158526427674,
       "offset": [
-        -1936.9884239637872,
-        1969.438456906274
+        -1031.7966929593308,
+        2163.3887579005113
       ]
     },
-    "frontendVersion": "1.26.3",
+    "frontendVersion": "1.42.8",
     "node_versions": {
       "ComfyUI-WanVideoWrapper": "0a11c67a0c0062b534178920a0d6dcaa75e7b5fe",
       "comfy-core": "0.3.43",
@@ -234,7 +378,9 @@
     "VHS_latentpreview": true,
     "VHS_latentpreviewrate": 0,
     "VHS_MetadataImage": true,
-    "VHS_KeepIntermediate": true
+    "VHS_KeepIntermediate": true,
+    "ue_links": [],
+    "links_added_by_ue": []
   },
   "version": 0.4
 }

--- a/nodes.py
+++ b/nodes.py
@@ -520,75 +520,123 @@ def _audio_to_mono(audio):
     return wav, sr
 
 
-def _log_spectrogram(wav, n_fft, hop_length):
-    """Compute log-magnitude spectrogram as a numpy float32 array [freq, time]."""
+_DB_FLOOR = -80.0   # dB floor — frequencies below this are clipped to black
+
+
+def _db_spectrogram(wav, n_fft, hop_length):
+    """Compute dB-magnitude spectrogram [freq, time], floored at _DB_FLOOR below peak."""
     import numpy as np
     window = torch.hann_window(n_fft)
     stft = torch.stft(wav, n_fft=n_fft, hop_length=hop_length,
                       window=window, return_complex=True)
     mag = stft.abs().numpy()
-    return np.log1p(mag)
+    db = 20.0 * np.log10(np.maximum(mag, 1e-8))
+    db = np.maximum(db, db.max() + _DB_FLOOR)
+    return db.astype(np.float32)
 
 
-def _render_figure(spec_a, spec_b, label_a, label_b, mode):
+def _spec_vrange(spec, percentile_lo=2.0):
+    """Return (vmin, vmax) using percentile clipping for contrast."""
+    import numpy as np
+    vmax = float(np.percentile(spec, 99.5))
+    vmin = float(np.percentile(spec, percentile_lo))
+    return vmin, vmax
+
+
+def _freq_yticks(n_fft, n_freqs, sr=44100):
+    """Return (tick_positions, tick_labels) for Hz axis after vertical flip."""
+    target_hz = [100, 500, 1000, 2000, 4000, 8000, 16000]
+    positions, labels = [], []
+    for hz in target_hz:
+        idx = int(hz * n_fft / sr)
+        if idx < n_freqs:
+            positions.append(n_freqs - 1 - idx)   # after [::-1] flip
+            labels.append(f"{hz // 1000}k" if hz >= 1000 else str(hz))
+    return positions, labels
+
+
+def _style_spec_ax(ax, spec, n_fft, cmap, xlabel=False, sr=44100):
+    """Draw spectrogram on ax with proper dB range, Hz ticks, colorbar."""
+    vmin, vmax = _spec_vrange(spec)
+    im = ax.imshow(spec, aspect="auto", cmap=cmap, origin="upper",
+                   vmin=vmin, vmax=vmax, interpolation="antialiased")
+    n_freqs = spec.shape[0]
+    tpos, tlbl = _freq_yticks(n_fft, n_freqs, sr)
+    ax.set_yticks(tpos)
+    ax.set_yticklabels(tlbl, fontsize=8)
+    ax.set_ylabel("Hz", fontsize=9)
+    if xlabel:
+        ax.set_xlabel("Time frames", fontsize=9)
+    ax.tick_params(axis="x", labelsize=8)
+    return im
+
+
+def _render_figure(spec_a, spec_b, label_a, label_b, mode, n_fft, sr=44100):
     """Render comparison figure → numpy [H, W, 3] uint8."""
     import numpy as np
     from matplotlib.figure import Figure
     from matplotlib.backends.backend_agg import FigureCanvasAgg
 
     min_t = min(spec_a.shape[1], spec_b.shape[1])
-    sa = spec_a[::-1, :min_t]   # flip: low freq at bottom
+    sa = spec_a[::-1, :min_t]
     sb = spec_b[::-1, :min_t]
 
+    CMAP = "inferno"
+    DPI = 150
+
     if mode == "stacked":
-        fig = Figure(figsize=(14, 6), tight_layout=True)
+        fig = Figure(figsize=(14, 6), dpi=DPI, tight_layout=True)
         ax_a = fig.add_subplot(2, 1, 1)
         ax_b = fig.add_subplot(2, 1, 2)
-        ax_a.imshow(sa, aspect="auto", cmap="magma", origin="upper")
+        _style_spec_ax(ax_a, sa, n_fft, CMAP, sr=sr)
         ax_a.set_title(label_a, fontsize=10)
-        ax_a.set_ylabel("Frequency")
-        ax_b.imshow(sb, aspect="auto", cmap="magma", origin="upper")
+        im = _style_spec_ax(ax_b, sb, n_fft, CMAP, xlabel=True, sr=sr)
         ax_b.set_title(label_b, fontsize=10)
-        ax_b.set_ylabel("Frequency")
-        ax_b.set_xlabel("Time (frames)")
+        fig.colorbar(im, ax=[ax_a, ax_b], label="dB", fraction=0.02, pad=0.01)
 
     elif mode == "difference":
         diff = sa - sb
-        max_val = float(np.abs(diff).max()) + 1e-8
-        fig = Figure(figsize=(14, 4), tight_layout=True)
+        abs_max = float(np.percentile(np.abs(diff), 99.5)) + 1e-8
+        fig = Figure(figsize=(14, 4), dpi=DPI, tight_layout=True)
         ax = fig.add_subplot(1, 1, 1)
-        im = ax.imshow(diff, aspect="auto", cmap="RdBu_r",
-                       vmin=-max_val, vmax=max_val, origin="upper")
-        ax.set_title(f"Difference  [{label_a}] − [{label_b}]  (red = A louder, blue = B louder)", fontsize=10)
-        ax.set_ylabel("Frequency")
-        ax.set_xlabel("Time (frames)")
-        fig.colorbar(im, ax=ax, fraction=0.02, pad=0.01)
+        n_freqs = sa.shape[0]
+        tpos, tlbl = _freq_yticks(n_fft, n_freqs, sr)
+        ax.set_yticks(tpos)
+        ax.set_yticklabels(tlbl, fontsize=8)
+        ax.set_ylabel("Hz", fontsize=9)
+        ax.set_xlabel("Time frames", fontsize=9)
+        im = ax.imshow(diff, aspect="auto", cmap="RdBu_r", origin="upper",
+                       vmin=-abs_max, vmax=abs_max, interpolation="antialiased")
+        ax.set_title(f"[{label_a}] − [{label_b}]  ·  red = A louder  ·  blue = B louder", fontsize=10)
+        fig.colorbar(im, ax=ax, label="ΔdB", fraction=0.02, pad=0.01)
 
     else:  # stacked + difference
         diff = sa - sb
-        max_val = float(np.abs(diff).max()) + 1e-8
-        fig = Figure(figsize=(14, 9), tight_layout=True)
+        abs_max = float(np.percentile(np.abs(diff), 99.5)) + 1e-8
+        fig = Figure(figsize=(14, 9), dpi=DPI, tight_layout=True)
         ax_a = fig.add_subplot(3, 1, 1)
         ax_b = fig.add_subplot(3, 1, 2)
         ax_d = fig.add_subplot(3, 1, 3)
-        ax_a.imshow(sa, aspect="auto", cmap="magma", origin="upper")
+        _style_spec_ax(ax_a, sa, n_fft, CMAP, sr=sr)
         ax_a.set_title(label_a, fontsize=10)
-        ax_a.set_ylabel("Frequency")
-        ax_b.imshow(sb, aspect="auto", cmap="magma", origin="upper")
+        im_b = _style_spec_ax(ax_b, sb, n_fft, CMAP, sr=sr)
         ax_b.set_title(label_b, fontsize=10)
-        ax_b.set_ylabel("Frequency")
-        im = ax_d.imshow(diff, aspect="auto", cmap="RdBu_r",
-                         vmin=-max_val, vmax=max_val, origin="upper")
-        ax_d.set_title(f"Difference  [{label_a}] − [{label_b}]", fontsize=10)
-        ax_d.set_ylabel("Frequency")
-        ax_d.set_xlabel("Time (frames)")
-        fig.colorbar(im, ax=ax_d, fraction=0.02, pad=0.01)
+        fig.colorbar(im_b, ax=[ax_a, ax_b], label="dB", fraction=0.015, pad=0.01)
+        n_freqs = sa.shape[0]
+        tpos, tlbl = _freq_yticks(n_fft, n_freqs, sr)
+        ax_d.set_yticks(tpos)
+        ax_d.set_yticklabels(tlbl, fontsize=8)
+        ax_d.set_ylabel("Hz", fontsize=9)
+        ax_d.set_xlabel("Time frames", fontsize=9)
+        im_d = ax_d.imshow(diff, aspect="auto", cmap="RdBu_r", origin="upper",
+                           vmin=-abs_max, vmax=abs_max, interpolation="antialiased")
+        ax_d.set_title(f"[{label_a}] − [{label_b}]", fontsize=10)
+        fig.colorbar(im_d, ax=ax_d, label="ΔdB", fraction=0.015, pad=0.01)
 
     canvas = FigureCanvasAgg(fig)
     canvas.draw()
-    import numpy as np
     buf = canvas.buffer_rgba()
-    img = np.asarray(buf)[..., :3].copy()  # drop alpha, [H, W, 3] uint8
+    img = np.asarray(buf)[..., :3].copy()
     return img
 
 
@@ -629,10 +677,10 @@ class MelBandRoFormerSpectrogram:
         if sr_b != sr_target:
             wav_b = TAF.resample(wav_b.unsqueeze(0), sr_b, sr_target).squeeze(0)
 
-        spec_a = _log_spectrogram(wav_a, n_fft, hop_length)
-        spec_b = _log_spectrogram(wav_b, n_fft, hop_length)
+        spec_a = _db_spectrogram(wav_a, n_fft, hop_length)
+        spec_b = _db_spectrogram(wav_b, n_fft, hop_length)
 
-        img = _render_figure(spec_a, spec_b, label_a, label_b, mode)
+        img = _render_figure(spec_a, spec_b, label_a, label_b, mode, n_fft, sr=sr_target)
 
         img_tensor = torch.from_numpy(img).float() / 255.0  # [H, W, 3]
         img_tensor = img_tensor.unsqueeze(0)                 # [1, H, W, 3]

--- a/nodes.py
+++ b/nodes.py
@@ -892,11 +892,76 @@ class MelBandRoFormerSampler4Stem(MelBandRoFormerSampler):
         return [to_audio(estimated[i]) for i in range(num_stems)]
 
 
+class MelBandRoFormerLUFSNormalize:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "audio": ("AUDIO",),
+                "target_lufs": ("FLOAT", {
+                    "default": -14.0, "min": -70.0, "max": 0.0, "step": 0.5,
+                    "tooltip": "Target integrated loudness in LUFS. Common values: -14 (streaming), -23 (broadcast EBU R128), -16 (podcast).",
+                }),
+                "peak_limit_db": ("FLOAT", {
+                    "default": -1.0, "min": -20.0, "max": 0.0, "step": 0.5,
+                    "tooltip": "True-peak ceiling in dBFS after normalization. Prevents clipping.",
+                }),
+            },
+        }
+
+    RETURN_TYPES = ("AUDIO", "FLOAT", "FLOAT")
+    RETURN_NAMES = ("audio", "input_lufs", "applied_gain_db")
+    FUNCTION = "normalize"
+    CATEGORY = "Mel-Band RoFormer"
+
+    def normalize(self, audio, target_lufs=-14.0, peak_limit_db=-1.0):
+        try:
+            import pyloudnorm as pyln
+        except ImportError:
+            raise ImportError(
+                "pyloudnorm is required for LUFS normalization. "
+                "Install with:  pip install pyloudnorm"
+            )
+
+        waveform = audio["waveform"]   # [B, C, T]
+        sr = audio["sample_rate"]
+
+        wav = waveform[0].cpu().float()   # [C, T]
+        np_wav = wav.numpy().T            # [T, C] as pyloudnorm expects
+
+        meter = pyln.Meter(sr)
+        input_lufs = meter.integrated_loudness(np_wav)
+
+        if input_lufs == float("-inf"):
+            print("[MelBandRoFormer] LUFS Normalize: input is silent, skipping.")
+            return (audio, float("-inf"), 0.0)
+
+        gain_db = target_lufs - input_lufs
+        peak_limit_linear = 10 ** (peak_limit_db / 20.0)
+
+        gain_linear = 10 ** (gain_db / 20.0)
+        normalized = wav * gain_linear
+
+        # Clamp to peak limit
+        peak = normalized.abs().max().item()
+        if peak > peak_limit_linear:
+            clamp_gain = peak_limit_linear / peak
+            normalized = normalized * clamp_gain
+            gain_db += 20.0 * torch.log10(torch.tensor(clamp_gain)).item()
+            print(f"[MelBandRoFormer] LUFS Normalize: peak clamped by {20.0 * (clamp_gain - 1):.2f} dB")
+
+        print(f"[MelBandRoFormer] LUFS Normalize: {input_lufs:.1f} → {target_lufs:.1f} LUFS  (gain {gain_db:+.1f} dB)")
+
+        out = {"waveform": normalized.unsqueeze(0), "sample_rate": sr}
+        return (out, round(input_lufs, 2), round(gain_db, 2))
+
+
 NODE_CLASS_MAPPINGS = {
     "MelBandRoFormerModelLoader": MelBandRoFormerModelLoader,
     "MelBandRoFormerModelLoaderLatest": MelBandRoFormerModelLoaderLatest,
     "MelBandRoFormerSampler": MelBandRoFormerSampler,
     "MelBandRoFormerSampler4Stem": MelBandRoFormerSampler4Stem,
+    "MelBandRoFormerLUFSNormalize": MelBandRoFormerLUFSNormalize,
     "MelBandRoFormerSpectrogram": MelBandRoFormerSpectrogram,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -904,5 +969,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "MelBandRoFormerModelLoaderLatest": "Mel-Band RoFormer Model Loader (Latest)",
     "MelBandRoFormerSampler": "Mel-Band RoFormer Sampler",
     "MelBandRoFormerSampler4Stem": "Mel-Band RoFormer Sampler (4-stem)",
+    "MelBandRoFormerLUFSNormalize": "Mel-Band RoFormer LUFS Normalize",
     "MelBandRoFormerSpectrogram": "Mel-Band RoFormer Spectrogram",
 }

--- a/nodes.py
+++ b/nodes.py
@@ -124,6 +124,16 @@ MODEL_REGISTRY = {
 }
 
 _HF_PREFIX = "[HF] "
+_ACK_FILE = os.path.join(folder_paths.get_folder_paths("MelBandRoFormer")[0], ".ckpt_risk_acknowledged")
+
+
+def _ckpt_acknowledged():
+    return os.path.exists(_ACK_FILE)
+
+
+def _save_ckpt_ack():
+    with open(_ACK_FILE, "w") as f:
+        f.write("acknowledged")
 
 
 def _hf_model_choices():
@@ -247,6 +257,17 @@ class MelBandRoFormerModelLoader:
                         ),
                     },
                 ),
+                "acknowledge_ckpt_risk": ("BOOLEAN", {
+                    "default": False,
+                    "tooltip": (
+                        "Most models use the .ckpt format, which is based on Python pickle. "
+                        "Pickle can execute arbitrary code when loaded — a malicious .ckpt file "
+                        "could run anything on your machine. All models in this registry come from "
+                        "known, trusted authors on HuggingFace, so the practical risk is low. "
+                        "Check this box to confirm you understand and accept this risk. "
+                        "Your acknowledgment is saved to disk and won't be asked again."
+                    ),
+                }),
             },
         }
 
@@ -255,10 +276,23 @@ class MelBandRoFormerModelLoader:
     FUNCTION = "loadmodel"
     CATEGORY = "Mel-Band RoFormer"
 
-    def loadmodel(self, model_name):
+    def loadmodel(self, model_name, acknowledge_ckpt_risk=False):
         if model_name.startswith(_HF_PREFIX):
             display_name = model_name[len(_HF_PREFIX):]
             repo_id, filename = MODEL_REGISTRY[display_name]
+            if filename.endswith(".ckpt") and not _ckpt_acknowledged():
+                if not acknowledge_ckpt_risk:
+                    raise ValueError(
+                        "[MelBandRoFormer] This model uses the .ckpt format, which is based on Python pickle.\n"
+                        "Pickle files can execute arbitrary code when loaded — a malicious .ckpt could run "
+                        "anything on your machine.\n"
+                        "The models in this registry come from known, trusted authors on HuggingFace, "
+                        "so the practical risk is low, but you should be aware of it.\n\n"
+                        "To proceed: check the 'acknowledge_ckpt_risk' box on the Loader node and run again. "
+                        "Your acknowledgment will be saved and you won't be asked again."
+                    )
+                _save_ckpt_ack()
+                print("[MelBandRoFormer] .ckpt risk acknowledged and saved.")
             model_path = download_hf_model(repo_id, filename)
         else:
             model_path = folder_paths.get_full_path_or_raise("MelBandRoFormer", model_name)

--- a/nodes.py
+++ b/nodes.py
@@ -446,11 +446,140 @@ class MelBandRoFormerSampler:
         return (to_audio(stem1), to_audio(stem2))
 
 
+def _audio_to_mono(audio):
+    """Return (mono_wav [T], sample_rate) from a ComfyUI AUDIO dict."""
+    waveform = audio["waveform"]  # [B, C, T]
+    sr = audio["sample_rate"]
+    wav = waveform[0].mean(0).cpu().float()  # [T]
+    return wav, sr
+
+
+def _log_spectrogram(wav, n_fft, hop_length):
+    """Compute log-magnitude spectrogram as a numpy float32 array [freq, time]."""
+    import numpy as np
+    window = torch.hann_window(n_fft)
+    stft = torch.stft(wav, n_fft=n_fft, hop_length=hop_length,
+                      window=window, return_complex=True)
+    mag = stft.abs().numpy()
+    return np.log1p(mag)
+
+
+def _render_figure(spec_a, spec_b, label_a, label_b, mode):
+    """Render comparison figure → numpy [H, W, 3] uint8."""
+    import numpy as np
+    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+    min_t = min(spec_a.shape[1], spec_b.shape[1])
+    sa = spec_a[::-1, :min_t]   # flip: low freq at bottom
+    sb = spec_b[::-1, :min_t]
+
+    if mode == "stacked":
+        fig = Figure(figsize=(14, 6), tight_layout=True)
+        ax_a = fig.add_subplot(2, 1, 1)
+        ax_b = fig.add_subplot(2, 1, 2)
+        ax_a.imshow(sa, aspect="auto", cmap="magma", origin="upper")
+        ax_a.set_title(label_a, fontsize=10)
+        ax_a.set_ylabel("Frequency")
+        ax_b.imshow(sb, aspect="auto", cmap="magma", origin="upper")
+        ax_b.set_title(label_b, fontsize=10)
+        ax_b.set_ylabel("Frequency")
+        ax_b.set_xlabel("Time (frames)")
+
+    elif mode == "difference":
+        diff = sa - sb
+        max_val = float(np.abs(diff).max()) + 1e-8
+        fig = Figure(figsize=(14, 4), tight_layout=True)
+        ax = fig.add_subplot(1, 1, 1)
+        im = ax.imshow(diff, aspect="auto", cmap="RdBu_r",
+                       vmin=-max_val, vmax=max_val, origin="upper")
+        ax.set_title(f"Difference  [{label_a}] − [{label_b}]  (red = A louder, blue = B louder)", fontsize=10)
+        ax.set_ylabel("Frequency")
+        ax.set_xlabel("Time (frames)")
+        fig.colorbar(im, ax=ax, fraction=0.02, pad=0.01)
+
+    else:  # stacked + difference
+        diff = sa - sb
+        max_val = float(np.abs(diff).max()) + 1e-8
+        fig = Figure(figsize=(14, 9), tight_layout=True)
+        ax_a = fig.add_subplot(3, 1, 1)
+        ax_b = fig.add_subplot(3, 1, 2)
+        ax_d = fig.add_subplot(3, 1, 3)
+        ax_a.imshow(sa, aspect="auto", cmap="magma", origin="upper")
+        ax_a.set_title(label_a, fontsize=10)
+        ax_a.set_ylabel("Frequency")
+        ax_b.imshow(sb, aspect="auto", cmap="magma", origin="upper")
+        ax_b.set_title(label_b, fontsize=10)
+        ax_b.set_ylabel("Frequency")
+        im = ax_d.imshow(diff, aspect="auto", cmap="RdBu_r",
+                         vmin=-max_val, vmax=max_val, origin="upper")
+        ax_d.set_title(f"Difference  [{label_a}] − [{label_b}]", fontsize=10)
+        ax_d.set_ylabel("Frequency")
+        ax_d.set_xlabel("Time (frames)")
+        fig.colorbar(im, ax=ax_d, fraction=0.02, pad=0.01)
+
+    canvas = FigureCanvasAgg(fig)
+    canvas.draw()
+    import numpy as np
+    buf = canvas.buffer_rgba()
+    img = np.asarray(buf)[..., :3].copy()  # drop alpha, [H, W, 3] uint8
+    return img
+
+
+class MelBandRoFormerSpectrogram:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "audio_a": ("AUDIO", {}),
+                "audio_b": ("AUDIO", {}),
+                "label_a": ("STRING", {"default": "A"}),
+                "label_b": ("STRING", {"default": "B"}),
+                "mode": (["stacked", "difference", "stacked + difference"],),
+                "n_fft": ("INT", {
+                    "default": 2048, "min": 512, "max": 8192, "step": 512,
+                    "tooltip": "FFT size. Larger = better frequency resolution, lower time resolution.",
+                }),
+                "hop_length": ("INT", {
+                    "default": 512, "min": 64, "max": 2048, "step": 64,
+                    "tooltip": "Hop size in samples. Smaller = better time resolution.",
+                }),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("spectrogram",)
+    FUNCTION = "compare"
+    CATEGORY = "Mel-Band RoFormer"
+
+    def compare(self, audio_a, audio_b, label_a, label_b, mode, n_fft, hop_length):
+        sr_target = 44100
+
+        wav_a, sr_a = _audio_to_mono(audio_a)
+        wav_b, sr_b = _audio_to_mono(audio_b)
+
+        if sr_a != sr_target:
+            wav_a = TAF.resample(wav_a.unsqueeze(0), sr_a, sr_target).squeeze(0)
+        if sr_b != sr_target:
+            wav_b = TAF.resample(wav_b.unsqueeze(0), sr_b, sr_target).squeeze(0)
+
+        spec_a = _log_spectrogram(wav_a, n_fft, hop_length)
+        spec_b = _log_spectrogram(wav_b, n_fft, hop_length)
+
+        img = _render_figure(spec_a, spec_b, label_a, label_b, mode)
+
+        img_tensor = torch.from_numpy(img).float() / 255.0  # [H, W, 3]
+        img_tensor = img_tensor.unsqueeze(0)                 # [1, H, W, 3]
+        return (img_tensor,)
+
+
 NODE_CLASS_MAPPINGS = {
     "MelBandRoFormerModelLoader": MelBandRoFormerModelLoader,
     "MelBandRoFormerSampler": MelBandRoFormerSampler,
+    "MelBandRoFormerSpectrogram": MelBandRoFormerSpectrogram,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     "MelBandRoFormerModelLoader": "Mel-Band RoFormer Model Loader",
     "MelBandRoFormerSampler": "Mel-Band RoFormer Sampler",
+    "MelBandRoFormerSpectrogram": "Mel-Band RoFormer Spectrogram",
 }

--- a/nodes.py
+++ b/nodes.py
@@ -8,6 +8,12 @@ import folder_paths
 
 from .model.mel_band_roformer import MelBandRoformer
 
+try:
+    from bs_roformer import BSRoformer
+    _BS_ROFORMER_AVAILABLE = True
+except ImportError:
+    _BS_ROFORMER_AVAILABLE = False
+
 script_directory = os.path.dirname(os.path.abspath(__file__))
 
 from comfy import model_management as mm
@@ -16,11 +22,31 @@ device = mm.get_torch_device()
 offload_device = mm.unet_offload_device()
 
 # ---------------------------------------------------------------------------
-# Base config — all variable fields are overridden by infer_model_config()
+# Base configs — variable fields are overridden by infer_* functions
 # ---------------------------------------------------------------------------
-_BASE_CONFIG = {
+_MELBAND_BASE_CONFIG = {
     "stereo": True,
     "num_bands": 60,
+    "dim_head": 64,
+    "heads": 8,
+    "attn_dropout": 0,
+    "ff_dropout": 0,
+    "flash_attn": True,
+    "dim_freqs_in": 1025,
+    "sample_rate": 44100,
+    "stft_n_fft": 2048,
+    "stft_hop_length": 441,
+    "stft_win_length": 2048,
+    "stft_normalized": False,
+    "mask_estimator_depth": 2,
+    "multi_stft_resolution_loss_weight": 1.0,
+    "multi_stft_resolutions_window_sizes": (4096, 2048, 1024, 512, 256),
+    "multi_stft_hop_size": 147,
+    "multi_stft_normalized": False,
+}
+
+_BS_BASE_CONFIG = {
+    "stereo": True,
     "dim_head": 64,
     "heads": 8,
     "attn_dropout": 0,
@@ -89,6 +115,12 @@ MODEL_REGISTRY = {
     # ── Aspiration (breath/mouth sounds) ────────────────────────────────────
     "Aspiration · Sucial ⭐":                        ("Sucial/Aspiration_Mel_Band_Roformer",              "aspiration_mel_band_roformer_sdr_18.9845.ckpt"),
     "Aspiration less-aggressive · Sucial":           ("Sucial/Aspiration_Mel_Band_Roformer",              "aspiration_mel_band_roformer_less_aggr_sdr_18.1201.ckpt"),
+    # ── BS-RoFormer: Vocals (better bass, competitive vocals) ────────────────
+    "[BS] Vocals revive v3e ⭐ · pcunwa":            ("pcunwa/BS-Roformer-Revive",                        "bs_roformer_revive3e.ckpt"),
+    "[BS] Vocals revive v2 · pcunwa":                ("pcunwa/BS-Roformer-Revive",                        "bs_roformer_revive2.ckpt"),
+    "[BS] Vocals revive v1 · pcunwa":                ("pcunwa/BS-Roformer-Revive",                        "bs_roformer_revive.ckpt"),
+    # ── BS-RoFormer: Dereverb ────────────────────────────────────────────────
+    "[BS] Dereverb · anvuew ⭐ (SDR 22.51)":         ("anvuew/deverb_bs_roformer",                        "dereverb_bs_roformer_anvuew_sdr_22.5050.ckpt"),
 }
 
 _HF_PREFIX = "[HF] "
@@ -103,44 +135,70 @@ def _all_model_choices():
     return local + _hf_model_choices()
 
 
-def infer_model_config(sd):
-    """Auto-detect architecture parameters from a state dict."""
-    config = dict(_BASE_CONFIG)
+def _detect_model_type(sd):
+    """Return 'melband' or 'bsroformer' by checking whether band-split is overlapping."""
+    band_weights = [v for k, v in sd.items()
+                    if k.startswith('band_split.to_features.') and k.endswith('.1.weight')]
+    if not band_weights:
+        return 'melband'  # safe fallback
+    total_input = sum(w.shape[1] for w in band_weights)
+    # BSRoformer: non-overlapping bands → total = 2 * audio_channels * dim_freqs_in
+    # For stereo+complex: 4 * 1025 = 4100
+    # MelBandRoformer: overlapping mel bands → total > 4100 (typically ~6000-8000)
+    return 'bsroformer' if total_input <= 4 * 1025 else 'melband'
 
-    # dim: output size of the first band-split projection
+
+def _infer_shared_params(sd, config):
+    """Fill dim, depth, num_stems, transformer depths, mask_estimator_depth — shared logic."""
     config["dim"] = sd["band_split.to_features.0.1.weight"].shape[0]
-
-    # depth: number of (time-transformer, freq-transformer) blocks
     config["depth"] = max(int(k.split('.')[1]) for k in sd if k.startswith('layers.')) + 1
-
-    # num_stems: number of mask estimators
     config["num_stems"] = max(int(k.split('.')[1]) for k in sd if k.startswith('mask_estimators.')) + 1
 
-    # time_transformer_depth: layers inside the time transformer
-    # key format: layers.<block>.0.layers.<depth_idx>.<attn_or_ff>.*
     time_keys = [k for k in sd if k.startswith('layers.0.0.layers.')]
-    if time_keys:
-        config["time_transformer_depth"] = max(int(k.split('.')[4]) for k in time_keys) + 1
-    else:
-        config["time_transformer_depth"] = 1
+    config["time_transformer_depth"] = max(int(k.split('.')[4]) for k in time_keys) + 1 if time_keys else 1
 
-    # freq_transformer_depth: layers inside the freq transformer
     freq_keys = [k for k in sd if k.startswith('layers.0.1.layers.')]
-    if freq_keys:
-        config["freq_transformer_depth"] = max(int(k.split('.')[4]) for k in freq_keys) + 1
-    else:
-        config["freq_transformer_depth"] = 1
+    config["freq_transformer_depth"] = max(int(k.split('.')[4]) for k in freq_keys) + 1 if freq_keys else 1
 
-    # mask_estimator_depth: number of hidden layers in the mask MLP
-    # key format: mask_estimators.0.to_freqs.0.0.<seq_idx>.weight
-    # Linear layers sit at even seq indices: 0, 2, 4, ...  → depth = max_even_idx // 2
     mlp_keys = [k for k in sd if k.startswith('mask_estimators.0.to_freqs.0.0.') and k.endswith('.weight')]
     if mlp_keys:
-        max_idx = max(int(k.split('.')[5]) for k in mlp_keys)
-        config["mask_estimator_depth"] = max_idx // 2
-    # else: keep _BASE_CONFIG default (2)
+        config["mask_estimator_depth"] = max(int(k.split('.')[5]) for k in mlp_keys) // 2
+
+
+def infer_melband_config(sd):
+    """Auto-detect MelBandRoformer architecture from state dict."""
+    config = dict(_MELBAND_BASE_CONFIG)
+    _infer_shared_params(sd, config)
+    return config
+
+
+def infer_bs_roformer_config(sd):
+    """Auto-detect BSRoformer architecture from state dict."""
+    config = dict(_BS_BASE_CONFIG)
+    _infer_shared_params(sd, config)
+
+    # Reconstruct freqs_per_bands from the band_split input layer shapes.
+    # Each band N: band_split.to_features.N.1.weight shape = [dim, 2 * freqs[N] * channels]
+    band_keys = sorted(
+        (int(k.split('.')[3]), k)
+        for k in sd
+        if k.startswith('band_split.to_features.') and k.endswith('.1.weight')
+    )
+    # Detect stereo: input divisible by 4 (2 complex × 2 ch) vs 2 (2 complex × 1 ch)
+    first_input = sd[band_keys[0][1]].shape[1]
+    divisor = 4 if first_input % 4 == 0 else 2
+    config["stereo"] = (divisor == 4)
+    config["freqs_per_bands"] = tuple(sd[k].shape[1] // divisor for _, k in band_keys)
 
     return config
+
+
+def infer_config(sd):
+    """Detect model type and return (model_type, config)."""
+    model_type = _detect_model_type(sd)
+    if model_type == 'bsroformer':
+        return 'bsroformer', infer_bs_roformer_config(sd)
+    return 'melband', infer_melband_config(sd)
 
 
 def download_hf_model(repo_id, filename):
@@ -206,12 +264,21 @@ class MelBandRoFormerModelLoader:
             model_path = folder_paths.get_full_path_or_raise("MelBandRoFormer", model_name)
 
         sd = load_torch_file(model_path)
-        config = infer_model_config(sd)
-        print(f"[MelBandRoFormer] Detected config: dim={config['dim']}, depth={config['depth']}, "
+        model_type, config = infer_config(sd)
+        print(f"[MelBandRoFormer] Detected {model_type}: dim={config['dim']}, depth={config['depth']}, "
               f"num_stems={config['num_stems']}, time_depth={config['time_transformer_depth']}, "
               f"freq_depth={config['freq_transformer_depth']}")
 
-        model = MelBandRoformer(**config).eval()
+        if model_type == 'bsroformer':
+            if not _BS_ROFORMER_AVAILABLE:
+                raise ImportError(
+                    "BS-RoFormer model requires the bs_roformer package. "
+                    "Install with:  pip install BS-RoFormer"
+                )
+            model = BSRoformer(**config).eval()
+        else:
+            model = MelBandRoformer(**config).eval()
+
         model.load_state_dict(sd, strict=True)
         return (model,)
 

--- a/nodes.py
+++ b/nodes.py
@@ -520,15 +520,16 @@ class MelBandRoFormerSampler:
 
                 # accumulate each chunk in the batch
                 for idx, (i, length) in enumerate(zip(batch_starts, lengths)):
-                    out = batch_out[idx]                       # [stems, channels, C]
-                    window = windowing_array.clone()
+                    out = batch_out[idx]                       # [stems, channels, C_out]
+                    eff = min(length, out.shape[-1])            # model iSTFT may shorten C
+                    window = windowing_array[:eff].clone()
                     if i == 0:
                         window[:fade_samples] = 1
                     if i + C >= total_length:
                         window[-fade_samples:] = 1
 
-                    acc[..., i:i + length] += out[..., :length] * window[..., :length]
-                    cnt[..., i:i + length] += window[..., :length]
+                    acc[..., i:i + eff] += out[..., :eff] * window[..., :eff]
+                    cnt[..., i:i + eff] += window[..., :eff]
 
                 comfy_pbar.update(len(batch_starts))
 
@@ -874,13 +875,14 @@ class MelBandRoFormerSampler4Stem(MelBandRoFormerSampler):
 
                 for idx, (i, length) in enumerate(zip(batch_starts, lengths)):
                     out = batch_out[idx]
-                    window = windowing_array.clone()
+                    eff = min(length, out.shape[-1])
+                    window = windowing_array[:eff].clone()
                     if i == 0:
                         window[:fade_samples] = 1
                     if i + C >= total_length:
                         window[-fade_samples:] = 1
-                    acc[..., i:i + length] += out[..., :length] * window[..., :length]
-                    cnt[..., i:i + length] += window[..., :length]
+                    acc[..., i:i + eff] += out[..., :eff] * window[..., :eff]
+                    cnt[..., i:i + eff] += window[..., :eff]
 
                 comfy_pbar.update(len(batch_starts))
 

--- a/nodes.py
+++ b/nodes.py
@@ -126,6 +126,51 @@ MODEL_REGISTRY = {
 _HF_PREFIX = "[HF] "
 _ACK_FILE = os.path.join(folder_paths.get_folder_paths("MelBandRoFormer")[0], ".ckpt_risk_acknowledged")
 
+# Latest/best model from each series — shown in the curated loader node.
+# Older versions that are superseded are excluded (Kim FT v1, GaboxR67 fv6, etc.)
+_LATEST_MODEL_NAMES = frozenset({
+    # Vocals
+    "Vocals · Kim FT v2 ⭐ [pcunwa]",
+    "Vocals · Kim FT v2 bleedless [pcunwa]",
+    "Vocals · Kim fp16 ⭐ [Kijai]",
+    "Vocals · becruily",
+    "Vocals · GaboxR67 fv7",
+    "Vocals small · pcunwa",
+    # Instrumental
+    "Instrumental · GaboxR67 INSTV6 ⭐",
+    "Instrumental v2 (depth-12) · pcunwa ⭐",
+    "Instrumental · becruily",
+    # Big (dim=512)
+    "Vocals big beta6 (dim=512) · pcunwa ⭐",
+    "Vocals big beta7 · pcunwa",
+    # Karaoke
+    "Karaoke · aufr33/viperx ⭐",
+    "Karaoke · becruily (2-stem)",
+    "Karaoke · GaboxR67 V1",
+    # 2-stem direct
+    "Vocals+Instrumental 2-stem · becruily",
+    # 4-stem
+    "4-stem large · Aname-Tommy [stem_1=vox only]",
+    "4-stem XL · Aname-Tommy [stem_1=vox only]",
+    # Dereverb
+    "[BS] Dereverb · anvuew ⭐ (SDR 22.51)",
+    "Dereverb · anvuew ⭐ (SDR 19.17)",
+    "Dereverb mono-optimized · anvuew (SDR 20.40)",
+    "Dereverb less-aggressive · anvuew (SDR 18.80)",
+    "Dereverb+Echo v2 · Sucial",
+    "Dereverb big reverb · Sucial",
+    "Dereverb super-big reverb · Sucial",
+    "Dereverb+Echo fused · Sucial",
+    # Denoise
+    "Denoise · aufr33 ⭐",
+    "Denoise aggressive · aufr33",
+    # Aspiration
+    "Aspiration · Sucial ⭐",
+    "Aspiration less-aggressive · Sucial",
+    # BS-RoFormer vocals
+    "[BS] Vocals revive v3e ⭐ · pcunwa",
+})
+
 
 def _ckpt_acknowledged():
     return os.path.exists(_ACK_FILE)
@@ -140,9 +185,18 @@ def _hf_model_choices():
     return [_HF_PREFIX + name for name in MODEL_REGISTRY]
 
 
+def _latest_hf_model_choices():
+    return [_HF_PREFIX + name for name in MODEL_REGISTRY if name in _LATEST_MODEL_NAMES]
+
+
 def _all_model_choices():
     local = folder_paths.get_filename_list("MelBandRoFormer")
     return local + _hf_model_choices()
+
+
+def _latest_model_choices():
+    local = folder_paths.get_filename_list("MelBandRoFormer")
+    return local + _latest_hf_model_choices()
 
 
 def _detect_model_type(sd):
@@ -573,13 +627,53 @@ class MelBandRoFormerSpectrogram:
         return (img_tensor,)
 
 
+class MelBandRoFormerModelLoaderLatest(MelBandRoFormerModelLoader):
+    """Curated loader — shows only the latest/best model from each series."""
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model_name": (
+                    _latest_model_choices(),
+                    {
+                        "tooltip": (
+                            "Curated list showing only the latest or best model from each series. "
+                            "Older superseded versions are hidden. "
+                            "Use the full Model Loader node to access every available model. "
+                            "Local files appear first; '[HF]' entries auto-download on first use."
+                        ),
+                    },
+                ),
+                "acknowledge_ckpt_risk": ("BOOLEAN", {
+                    "default": False,
+                    "tooltip": (
+                        "Most models use the .ckpt format, which is based on Python pickle. "
+                        "Pickle can execute arbitrary code when loaded — a malicious .ckpt file "
+                        "could run anything on your machine. All models in this registry come from "
+                        "known, trusted authors on HuggingFace, so the practical risk is low. "
+                        "Check this box to confirm you understand and accept this risk. "
+                        "Your acknowledgment is saved to disk and won't be asked again."
+                    ),
+                }),
+            },
+        }
+
+    RETURN_TYPES = ("MELROFORMERMODEL",)
+    RETURN_NAMES = ("model",)
+    FUNCTION = "loadmodel"
+    CATEGORY = "Mel-Band RoFormer"
+
+
 NODE_CLASS_MAPPINGS = {
     "MelBandRoFormerModelLoader": MelBandRoFormerModelLoader,
+    "MelBandRoFormerModelLoaderLatest": MelBandRoFormerModelLoaderLatest,
     "MelBandRoFormerSampler": MelBandRoFormerSampler,
     "MelBandRoFormerSpectrogram": MelBandRoFormerSpectrogram,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     "MelBandRoFormerModelLoader": "Mel-Band RoFormer Model Loader",
+    "MelBandRoFormerModelLoaderLatest": "Mel-Band RoFormer Model Loader (Latest)",
     "MelBandRoFormerSampler": "Mel-Band RoFormer Sampler",
     "MelBandRoFormerSpectrogram": "Mel-Band RoFormer Spectrogram",
 }

--- a/nodes.py
+++ b/nodes.py
@@ -189,10 +189,28 @@ _REGISTRY_FILENAMES = frozenset(
 )
 
 
+_MODEL_EXTENSIONS = {".ckpt", ".safetensors", ".pt", ".pth"}
+
+
 def _manual_local_choices():
-    """Local files that are NOT part of the registry (manually dropped in by the user)."""
-    return [f for f in folder_paths.get_filename_list("MelBandRoFormer")
-            if os.path.basename(f) not in _REGISTRY_FILENAMES]
+    """Local model files not managed by the registry.
+
+    Filters out:
+    - Non-model files (.metadata, .json, .ckpt_risk_acknowledged, etc.)
+    - Hidden files / dotfiles
+    - Files whose basename matches a registry entry (already shown as [HF])
+    """
+    result = []
+    for f in folder_paths.get_filename_list("MelBandRoFormer"):
+        base = os.path.basename(f)
+        if base.startswith("."):
+            continue
+        if os.path.splitext(base)[1].lower() not in _MODEL_EXTENSIONS:
+            continue
+        if base in _REGISTRY_FILENAMES:
+            continue
+        result.append(f)
+    return result
 
 
 def _hf_model_choices():

--- a/nodes.py
+++ b/nodes.py
@@ -624,11 +624,12 @@ def _render_figure(spec_a, spec_b, label_a, label_b, mode, n_fft, sr=44100):
         fig = Figure(figsize=(14, 6), dpi=DPI, tight_layout=True)
         ax_a = fig.add_subplot(2, 1, 1)
         ax_b = fig.add_subplot(2, 1, 2)
-        _draw_spec(ax_a, sa, vmin, vmax, CMAP, tpos, tlbl)
+        im_a = _draw_spec(ax_a, sa, vmin, vmax, CMAP, tpos, tlbl)
         ax_a.set_title(label_a, fontsize=10)
         im = _draw_spec(ax_b, sb, vmin, vmax, CMAP, tpos, tlbl, xlabel=True)
         ax_b.set_title(label_b, fontsize=10)
-        fig.colorbar(im, ax=[ax_a, ax_b], label="dB", fraction=0.02, pad=0.01)
+        fig.colorbar(im_a, ax=ax_a, label="dB", fraction=0.02, pad=0.01)
+        fig.colorbar(im, ax=ax_b, label="dB", fraction=0.02, pad=0.01)
 
     elif mode == "difference":
         diff = sa - sb
@@ -652,11 +653,12 @@ def _render_figure(spec_a, spec_b, label_a, label_b, mode, n_fft, sr=44100):
         ax_a = fig.add_subplot(3, 1, 1)
         ax_b = fig.add_subplot(3, 1, 2)
         ax_d = fig.add_subplot(3, 1, 3)
-        _draw_spec(ax_a, sa, vmin, vmax, CMAP, tpos, tlbl)
+        im_a = _draw_spec(ax_a, sa, vmin, vmax, CMAP, tpos, tlbl)
         ax_a.set_title(label_a, fontsize=10)
         im_b = _draw_spec(ax_b, sb, vmin, vmax, CMAP, tpos, tlbl)
         ax_b.set_title(label_b, fontsize=10)
-        fig.colorbar(im_b, ax=[ax_a, ax_b], label="dB", fraction=0.015, pad=0.01)
+        fig.colorbar(im_a, ax=ax_a, label="dB", fraction=0.015, pad=0.01)
+        fig.colorbar(im_b, ax=ax_b, label="dB", fraction=0.015, pad=0.01)
         im_d = ax_d.imshow(diff, aspect="auto", cmap="RdBu_r", origin="upper",
                            vmin=-abs_max, vmax=abs_max, interpolation="antialiased")
         ax_d.set_yticks(tpos)

--- a/nodes.py
+++ b/nodes.py
@@ -181,6 +181,20 @@ def _save_ckpt_ack():
         f.write("acknowledged")
 
 
+# Basenames of every file managed by the registry.
+# Used to suppress local duplicates: if a model was downloaded via [HF],
+# its bare filename is hidden from the local list so it only appears once.
+_REGISTRY_FILENAMES = frozenset(
+    os.path.basename(filename) for _, filename in MODEL_REGISTRY.values()
+)
+
+
+def _manual_local_choices():
+    """Local files that are NOT part of the registry (manually dropped in by the user)."""
+    return [f for f in folder_paths.get_filename_list("MelBandRoFormer")
+            if os.path.basename(f) not in _REGISTRY_FILENAMES]
+
+
 def _hf_model_choices():
     return [_HF_PREFIX + name for name in MODEL_REGISTRY]
 
@@ -190,13 +204,11 @@ def _latest_hf_model_choices():
 
 
 def _all_model_choices():
-    local = folder_paths.get_filename_list("MelBandRoFormer")
-    return local + _hf_model_choices()
+    return _manual_local_choices() + _hf_model_choices()
 
 
 def _latest_model_choices():
-    local = folder_paths.get_filename_list("MelBandRoFormer")
-    return local + _latest_hf_model_choices()
+    return _manual_local_choices() + _latest_hf_model_choices()
 
 
 def _detect_model_type(sd):

--- a/nodes.py
+++ b/nodes.py
@@ -123,7 +123,6 @@ MODEL_REGISTRY = {
     "[BS] Dereverb · anvuew ⭐ (SDR 22.51)":         ("anvuew/deverb_bs_roformer",                        "dereverb_bs_roformer_anvuew_sdr_22.5050.ckpt"),
 }
 
-_HF_PREFIX = "[HF] "
 _ACK_FILE = os.path.join(folder_paths.get_folder_paths("MelBandRoFormer")[0], ".ckpt_risk_acknowledged")
 
 # Latest/best model from each series — shown in the curated loader node.
@@ -214,11 +213,11 @@ def _manual_local_choices():
 
 
 def _hf_model_choices():
-    return [_HF_PREFIX + name for name in MODEL_REGISTRY]
+    return list(MODEL_REGISTRY.keys())
 
 
 def _latest_hf_model_choices():
-    return [_HF_PREFIX + name for name in MODEL_REGISTRY if name in _LATEST_MODEL_NAMES]
+    return [name for name in MODEL_REGISTRY if name in _LATEST_MODEL_NAMES]
 
 
 def _all_model_choices():
@@ -336,8 +335,7 @@ class MelBandRoFormerModelLoader:
                     {
                         "tooltip": (
                             "Local files from ComfyUI/models/MelBandRoFormer/ come first. "
-                            "Entries starting with '[HF]' are downloaded automatically from HuggingFace "
-                            "into that folder on first use."
+                            "Registry models are downloaded automatically from HuggingFace on first use."
                         ),
                     },
                 ),
@@ -361,9 +359,8 @@ class MelBandRoFormerModelLoader:
     CATEGORY = "Mel-Band RoFormer"
 
     def loadmodel(self, model_name, acknowledge_ckpt_risk=False):
-        if model_name.startswith(_HF_PREFIX):
-            display_name = model_name[len(_HF_PREFIX):]
-            repo_id, filename = MODEL_REGISTRY[display_name]
+        if model_name in MODEL_REGISTRY:
+            repo_id, filename = MODEL_REGISTRY[model_name]
             if filename.endswith(".ckpt") and not _ckpt_acknowledged():
                 if not acknowledge_ckpt_risk:
                     raise ValueError(
@@ -737,7 +734,7 @@ class MelBandRoFormerModelLoaderLatest(MelBandRoFormerModelLoader):
                             "Curated list showing only the latest or best model from each series. "
                             "Older superseded versions are hidden. "
                             "Use the full Model Loader node to access every available model. "
-                            "Local files appear first; '[HF]' entries auto-download on first use."
+                            "Local files appear first; registry models auto-download on first use."
                         ),
                     },
                 ),

--- a/nodes.py
+++ b/nodes.py
@@ -444,6 +444,10 @@ class MelBandRoFormerSampler:
                     "default": 1, "min": 1, "max": 16, "step": 1,
                     "tooltip": "Number of chunks processed in parallel. Higher = faster but more VRAM. Start at 1 and increase until you hit OOM.",
                 }),
+                "intensity": ("FLOAT", {
+                    "default": 1.0, "min": 0.0, "max": 1.0, "step": 0.05,
+                    "tooltip": "Separation intensity. 1.0 = full separation (default). Lower values blend each stem back toward the original mix.",
+                }),
             },
         }
 
@@ -452,7 +456,7 @@ class MelBandRoFormerSampler:
     FUNCTION = "process"
     CATEGORY = "Mel-Band RoFormer"
 
-    def process(self, model, audio, chunk_size=8.0, overlap=2, fade_size=0.1, batch_size=1):
+    def process(self, model, audio, chunk_size=8.0, overlap=2, fade_size=0.1, batch_size=1, intensity=1.0):
         audio_input = audio["waveform"]
         sample_rate = audio["sample_rate"]
 
@@ -543,6 +547,11 @@ class MelBandRoFormerSampler:
                       f"Stems 3–{num_stems} are discarded.")
         else:
             stem2 = original_audio.to(device) - stem1
+
+        if intensity < 1.0:
+            orig = original_audio.to(device)
+            stem1 = intensity * stem1 + (1.0 - intensity) * orig
+            stem2 = intensity * stem2 + (1.0 - intensity) * orig
 
         def to_audio(t):
             return {"waveform": t.unsqueeze(0).cpu(), "sample_rate": sr}
@@ -793,8 +802,8 @@ class MelBandRoFormerSampler4Stem(MelBandRoFormerSampler):
     FUNCTION = "process4"
     CATEGORY = "Mel-Band RoFormer"
 
-    def process4(self, model, audio, chunk_size=8.0, overlap=2, fade_size=0.1, batch_size=1):
-        stems = self._process_all(model, audio, chunk_size, overlap, fade_size, batch_size)
+    def process4(self, model, audio, chunk_size=8.0, overlap=2, fade_size=0.1, batch_size=1, intensity=1.0):
+        stems = self._process_all(model, audio, chunk_size, overlap, fade_size, batch_size, intensity)
         sr = stems[0]["sample_rate"]
         length = stems[0]["waveform"].shape[-1]
         channels = stems[0]["waveform"].shape[1]
@@ -806,7 +815,7 @@ class MelBandRoFormerSampler4Stem(MelBandRoFormerSampler):
 
         return (_get(0), _get(1), _get(2), _get(3))
 
-    def _process_all(self, model, audio, chunk_size, overlap, fade_size, batch_size):
+    def _process_all(self, model, audio, chunk_size, overlap, fade_size, batch_size, intensity=1.0):
         """Run inference and return a list of all stem AUDIO dicts."""
         audio_input = audio["waveform"]
         sample_rate = audio["sample_rate"]
@@ -887,7 +896,15 @@ class MelBandRoFormerSampler4Stem(MelBandRoFormerSampler):
         if num_stems == 1:
             stem1 = estimated[0]
             stem2 = original_audio.to(device) - stem1
+            if intensity < 1.0:
+                orig = original_audio.to(device)
+                stem1 = intensity * stem1 + (1.0 - intensity) * orig
+                stem2 = intensity * stem2 + (1.0 - intensity) * orig
             return [to_audio(stem1), to_audio(stem2)]
+
+        if intensity < 1.0:
+            orig = original_audio.to(device)
+            estimated = intensity * estimated + (1.0 - intensity) * orig
 
         return [to_audio(estimated[i]) for i in range(num_stems)]
 

--- a/nodes.py
+++ b/nodes.py
@@ -294,6 +294,27 @@ def infer_config(sd):
     return 'melband', infer_melband_config(sd)
 
 
+def _recommended_chunk_size(model_name, config):
+    """Estimate a good chunk_size (seconds) from model name and inferred config."""
+    name = model_name.lower()
+    num_stems = config.get("num_stems", 1)
+    dim = config.get("dim", 256)
+
+    if any(x in name for x in ("dereverb", "deverb", "echo")):
+        base = 12.0   # reverb tails can extend several seconds
+    elif any(x in name for x in ("denoise", "aspiration")):
+        base = 6.0    # stationary/transient content — less context needed
+    elif num_stems >= 4:
+        base = 10.0   # more simultaneous sources need more context
+    else:
+        base = 8.0    # general vocal / instrumental
+
+    if dim >= 512:
+        base = max(4.0, base - 2.0)   # wider model uses more VRAM per chunk
+
+    return base
+
+
 def download_hf_model(repo_id, filename):
     """Download a model from HuggingFace into ComfyUI's diffusion_models folder."""
     try:
@@ -353,8 +374,8 @@ class MelBandRoFormerModelLoader:
             },
         }
 
-    RETURN_TYPES = ("MELROFORMERMODEL",)
-    RETURN_NAMES = ("model",)
+    RETURN_TYPES = ("MELROFORMERMODEL", "FLOAT")
+    RETURN_NAMES = ("model", "recommended_chunk_size")
     FUNCTION = "loadmodel"
     CATEGORY = "Mel-Band RoFormer"
 
@@ -395,7 +416,9 @@ class MelBandRoFormerModelLoader:
             model = MelBandRoformer(**config).eval()
 
         model.load_state_dict(sd, strict=True)
-        return (model,)
+        chunk_rec = _recommended_chunk_size(model_name, config)
+        print(f"[MelBandRoFormer] Recommended chunk_size: {chunk_rec}s")
+        return (model, chunk_rec)
 
 
 class MelBandRoFormerSampler:
@@ -752,8 +775,8 @@ class MelBandRoFormerModelLoaderLatest(MelBandRoFormerModelLoader):
             },
         }
 
-    RETURN_TYPES = ("MELROFORMERMODEL",)
-    RETURN_NAMES = ("model",)
+    RETURN_TYPES = ("MELROFORMERMODEL", "FLOAT")
+    RETURN_NAMES = ("model", "recommended_chunk_size")
     FUNCTION = "loadmodel"
     CATEGORY = "Mel-Band RoFormer"
 

--- a/nodes.py
+++ b/nodes.py
@@ -44,30 +44,51 @@ _BASE_CONFIG = {
 # ---------------------------------------------------------------------------
 MODEL_REGISTRY = {
     # ── Vocals ──────────────────────────────────────────────────────────────
-    "Vocals · Kim fp16 ⭐ [Kijai]":          ("Kijai/MelBandRoFormer_comfy",                           "MelBandRoformer_fp16.safetensors"),
-    "Vocals · Kim fp32 [Kijai]":             ("Kijai/MelBandRoFormer_comfy",                           "MelBandRoformer_fp32.safetensors"),
-    "Vocals · Kim original [KimberleyJSN]":  ("KimberleyJSN/melbandroformer",                          "MelBandRoformer.ckpt"),
-    "Vocals · becruily":                     ("becruily/mel-band-roformer-vocals",                     "mel_band_roformer_vocals_becruily.ckpt"),
-    "Vocals small · pcunwa":                 ("pcunwa/Mel-Band-Roformer-small",                        "melband_roformer_small_v1.ckpt"),
+    "Vocals · Kim fp16 ⭐ [Kijai]":                  ("Kijai/MelBandRoFormer_comfy",                      "MelBandRoformer_fp16.safetensors"),
+    "Vocals · Kim fp32 [Kijai]":                     ("Kijai/MelBandRoFormer_comfy",                      "MelBandRoformer_fp32.safetensors"),
+    "Vocals · Kim original [KimberleyJSN]":          ("KimberleyJSN/melbandroformer",                     "MelBandRoformer.ckpt"),
+    "Vocals · Kim FT v2 ⭐ [pcunwa]":                ("pcunwa/Kim-Mel-Band-Roformer-FT",                  "kimmel_unwa_ft2.ckpt"),
+    "Vocals · Kim FT v2 bleedless [pcunwa]":         ("pcunwa/Kim-Mel-Band-Roformer-FT",                  "kimmel_unwa_ft2_bleedless.ckpt"),
+    "Vocals · Kim FT v1 [pcunwa]":                   ("pcunwa/Kim-Mel-Band-Roformer-FT",                  "kimmel_unwa_ft.ckpt"),
+    "Vocals · becruily":                             ("becruily/mel-band-roformer-vocals",                "mel_band_roformer_vocals_becruily.ckpt"),
+    "Vocals · GaboxR67 fv7":                         ("GaboxR67/MelBandRoformers",                        "melbandroformers/vocals/voc_fv7.ckpt"),
+    "Vocals · GaboxR67 fv6":                         ("GaboxR67/MelBandRoformers",                        "melbandroformers/vocals/voc_fv6.ckpt"),
+    "Vocals small · pcunwa":                         ("pcunwa/Mel-Band-Roformer-small",                   "melband_roformer_small_v1.ckpt"),
     # ── Instrumental ────────────────────────────────────────────────────────
-    "Instrumental · becruily":               ("becruily/mel-band-roformer-instrumental",               "mel_band_roformer_instrumental_becruily.ckpt"),
+    "Instrumental · becruily":                       ("becruily/mel-band-roformer-instrumental",          "mel_band_roformer_instrumental_becruily.ckpt"),
+    "Instrumental v2 (depth-12) · pcunwa ⭐":        ("pcunwa/Mel-Band-Roformer-Inst",                    "melband_roformer_inst_v2.ckpt"),
+    "Instrumental v1 · pcunwa":                      ("pcunwa/Mel-Band-Roformer-Inst",                    "melband_roformer_inst_v1.ckpt"),
+    "Instrumental · GaboxR67 INSTV6 ⭐":             ("GaboxR67/MelBandRoformers",                        "melbandroformers/instrumental/INSTV6.ckpt"),
+    "Instrumental · GaboxR67 Fv9":                   ("GaboxR67/MelBandRoformers",                        "melbandroformers/instrumental/Inst_GaboxFv9.ckpt"),
+    "Instrumental · GaboxR67 Fv8":                   ("GaboxR67/MelBandRoformers",                        "melbandroformers/instrumental/Inst_GaboxFv8.ckpt"),
+    # ── Big models (dim=512) ─────────────────────────────────────────────────
+    "Vocals big beta6 (dim=512) · pcunwa ⭐":        ("pcunwa/Mel-Band-Roformer-big",                     "big_beta6.ckpt"),
+    "Vocals big beta6x (dim=512) · pcunwa":          ("pcunwa/Mel-Band-Roformer-big",                     "big_beta6x.ckpt"),
+    "Vocals big beta7 · pcunwa":                     ("pcunwa/Mel-Band-Roformer-big",                     "big_beta7.ckpt"),
     # ── Karaoke (lead-vocal removal) ────────────────────────────────────────
-    "Karaoke · aufr33/viperx ⭐":            ("jarredou/aufr33-viperx-karaoke-melroformer-model",      "mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"),
-    "Karaoke · becruily (2-stem)":           ("becruily/mel-band-roformer-karaoke",                   "mel_band_roformer_karaoke_becruily.ckpt"),
+    "Karaoke · aufr33/viperx ⭐":                    ("jarredou/aufr33-viperx-karaoke-melroformer-model", "mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"),
+    "Karaoke · becruily (2-stem)":                   ("becruily/mel-band-roformer-karaoke",               "mel_band_roformer_karaoke_becruily.ckpt"),
+    "Karaoke · GaboxR67 V1":                         ("GaboxR67/MelBandRoformers",                        "melbandroformers/karaoke/Karaoke_GaboxV1.ckpt"),
     # ── Vocals + Instrumental 2-stem ────────────────────────────────────────
-    "Vocals+Instrumental 2-stem · becruily": ("becruily/mel-band-roformer-deux",                      "becruily_deux.ckpt"),
+    "Vocals+Instrumental 2-stem · becruily":         ("becruily/mel-band-roformer-deux",                  "becruily_deux.ckpt"),
+    # ── 4-stem (vocals, drums, bass, other) ─────────────────────────────────
+    "4-stem large · Aname-Tommy [stem_1=vox only]":  ("Aname-Tommy/melbandroformer4stems",                "mel_band_roformer_4stems_large_ver1.ckpt"),
+    "4-stem XL · Aname-Tommy [stem_1=vox only]":     ("Aname-Tommy/melbandroformer4stems",                "mel_band_roformer_4stems_xl_ver1.ckpt"),
     # ── Dereverb / Echo removal ─────────────────────────────────────────────
-    "Dereverb+Echo v2 · Sucial ⭐":          ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "dereverb_echo_mbr_v2_sdr_dry_13.4843.ckpt"),
-    "Dereverb+Echo fused · Sucial":          ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "dereverb_echo_mbr_fused_0.5_v2_0.25_big_0.25_super.ckpt"),
-    "Dereverb big reverb · Sucial":          ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "de_big_reverb_mbr_ep_362.ckpt"),
-    "Dereverb super-big reverb · Sucial":    ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "de_super_big_reverb_mbr_ep_346.ckpt"),
-    "Dereverb+Echo v1 · Sucial":             ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "dereverb-echo_mel_band_roformer_sdr_10.0169.ckpt"),
+    "Dereverb · anvuew ⭐ (SDR 19.17)":              ("anvuew/dereverb_mel_band_roformer",                "dereverb_mel_band_roformer_anvuew_sdr_19.1729.ckpt"),
+    "Dereverb less-aggressive · anvuew (SDR 18.80)": ("anvuew/dereverb_mel_band_roformer",                "dereverb_mel_band_roformer_less_aggressive_anvuew_sdr_18.8050.ckpt"),
+    "Dereverb mono-optimized · anvuew (SDR 20.40)":  ("anvuew/dereverb_mel_band_roformer",                "dereverb_mel_band_roformer_mono_anvuew_sdr_20.4029.ckpt"),
+    "Dereverb+Echo v2 · Sucial":                     ("Sucial/Dereverb-Echo_Mel_Band_Roformer",           "dereverb_echo_mbr_v2_sdr_dry_13.4843.ckpt"),
+    "Dereverb+Echo fused · Sucial":                  ("Sucial/Dereverb-Echo_Mel_Band_Roformer",           "dereverb_echo_mbr_fused_0.5_v2_0.25_big_0.25_super.ckpt"),
+    "Dereverb big reverb · Sucial":                  ("Sucial/Dereverb-Echo_Mel_Band_Roformer",           "de_big_reverb_mbr_ep_362.ckpt"),
+    "Dereverb super-big reverb · Sucial":            ("Sucial/Dereverb-Echo_Mel_Band_Roformer",           "de_super_big_reverb_mbr_ep_346.ckpt"),
+    "Dereverb+Echo v1 · Sucial":                     ("Sucial/Dereverb-Echo_Mel_Band_Roformer",           "dereverb-echo_mel_band_roformer_sdr_10.0169.ckpt"),
     # ── Denoise ─────────────────────────────────────────────────────────────
-    "Denoise · aufr33 ⭐":                   ("poiqazwsx/melband-roformer-denoise",                   "denoise_mel_band_roformer_aufr33_sdr_27.9959.ckpt"),
-    "Denoise aggressive · aufr33":           ("poiqazwsx/melband-roformer-denoise",                   "denoise_mel_band_roformer_aufr33_aggr_sdr_27.9768.ckpt"),
+    "Denoise · aufr33 ⭐":                           ("poiqazwsx/melband-roformer-denoise",               "denoise_mel_band_roformer_aufr33_sdr_27.9959.ckpt"),
+    "Denoise aggressive · aufr33":                   ("poiqazwsx/melband-roformer-denoise",               "denoise_mel_band_roformer_aufr33_aggr_sdr_27.9768.ckpt"),
     # ── Aspiration (breath/mouth sounds) ────────────────────────────────────
-    "Aspiration · Sucial ⭐":                ("Sucial/Aspiration_Mel_Band_Roformer",                   "aspiration_mel_band_roformer_sdr_18.9845.ckpt"),
-    "Aspiration less-aggressive · Sucial":   ("Sucial/Aspiration_Mel_Band_Roformer",                   "aspiration_mel_band_roformer_less_aggr_sdr_18.1201.ckpt"),
+    "Aspiration · Sucial ⭐":                        ("Sucial/Aspiration_Mel_Band_Roformer",              "aspiration_mel_band_roformer_sdr_18.9845.ckpt"),
+    "Aspiration less-aggressive · Sucial":           ("Sucial/Aspiration_Mel_Band_Roformer",              "aspiration_mel_band_roformer_less_aggr_sdr_18.1201.ckpt"),
 }
 
 _HF_PREFIX = "[HF] "
@@ -310,7 +331,13 @@ class MelBandRoFormerSampler:
             estimated = estimated[..., border:-border]
 
         stem1 = estimated[0]
-        stem2 = estimated[1] if num_stems >= 2 else (original_audio.to(device) - stem1)
+        if num_stems >= 2:
+            stem2 = estimated[1]
+            if num_stems > 2:
+                print(f"[MelBandRoFormer] Model has {num_stems} stems; only stem_1 and stem_2 are output. "
+                      f"Stems 3–{num_stems} are discarded.")
+        else:
+            stem2 = original_audio.to(device) - stem1
 
         def to_audio(t):
             return {"waveform": t.unsqueeze(0).cpu(), "sample_rate": sr}

--- a/nodes.py
+++ b/nodes.py
@@ -538,7 +538,8 @@ def _audio_to_mono(audio):
     return wav, sr
 
 
-_DB_FLOOR = -80.0   # dB floor — frequencies below this are clipped to black
+_DB_FLOOR = -80.0     # dB floor — bins below this relative to peak are black
+_LOG_FREQ_BINS = 256  # output rows after log-frequency resampling
 
 
 def _db_spectrogram(wav, n_fft, hop_length):
@@ -553,39 +554,52 @@ def _db_spectrogram(wav, n_fft, hop_length):
     return db.astype(np.float32)
 
 
-def _spec_vrange(spec, percentile_lo=2.0):
-    """Return (vmin, vmax) using percentile clipping for contrast."""
+def _to_log_freq(spec, n_out=_LOG_FREQ_BINS):
+    """Resample linear-frequency spectrogram to log-spaced frequency bins."""
     import numpy as np
-    vmax = float(np.percentile(spec, 99.5))
-    vmin = float(np.percentile(spec, percentile_lo))
-    return vmin, vmax
+    n_freqs, n_t = spec.shape
+    # Log-spaced source indices from bin 1 (avoid DC) to n_freqs-1
+    src_idx = np.logspace(0, np.log10(max(n_freqs - 1, 2)), n_out)
+    lo = np.floor(src_idx).astype(int).clip(0, n_freqs - 2)
+    hi = lo + 1
+    frac = (src_idx - lo)[:, None]                          # [n_out, 1]
+    return ((1 - frac) * spec[lo] + frac * spec[hi]).astype(np.float32)
 
 
-def _freq_yticks(n_fft, n_freqs, sr=44100):
-    """Return (tick_positions, tick_labels) for Hz axis after vertical flip."""
+def _log_freq_yticks(n_fft, n_out=_LOG_FREQ_BINS, sr=44100):
+    """Tick positions/labels for a log-freq resampled, vertically-flipped spectrogram."""
+    import numpy as np
+    n_freqs = n_fft // 2 + 1
+    src_idx = np.logspace(0, np.log10(max(n_freqs - 1, 2)), n_out)
     target_hz = [100, 500, 1000, 2000, 4000, 8000, 16000]
     positions, labels = [], []
     for hz in target_hz:
-        idx = int(hz * n_fft / sr)
-        if idx < n_freqs:
-            positions.append(n_freqs - 1 - idx)   # after [::-1] flip
-            labels.append(f"{hz // 1000}k" if hz >= 1000 else str(hz))
+        bin_f = hz * n_fft / sr
+        if bin_f < 1 or bin_f >= n_freqs:
+            continue
+        pos = int(np.searchsorted(src_idx, bin_f))
+        pos = min(pos, n_out - 1)
+        positions.append(n_out - 1 - pos)   # after [::-1] flip
+        labels.append(f"{hz // 1000}k" if hz >= 1000 else str(hz))
     return positions, labels
 
 
-def _style_spec_ax(ax, spec, n_fft, cmap, xlabel=False, sr=44100):
-    """Draw spectrogram on ax with proper dB range, Hz ticks, colorbar."""
-    vmin, vmax = _spec_vrange(spec)
+def _shared_vrange(*specs, percentile_lo=2.0):
+    """Compute vmin/vmax across all specs for a shared color scale."""
+    import numpy as np
+    combined = np.concatenate([s.ravel() for s in specs])
+    return float(np.percentile(combined, percentile_lo)), float(np.percentile(combined, 99.5))
+
+
+def _draw_spec(ax, spec, vmin, vmax, cmap, tpos, tlbl, xlabel=False):
     im = ax.imshow(spec, aspect="auto", cmap=cmap, origin="upper",
                    vmin=vmin, vmax=vmax, interpolation="antialiased")
-    n_freqs = spec.shape[0]
-    tpos, tlbl = _freq_yticks(n_fft, n_freqs, sr)
     ax.set_yticks(tpos)
     ax.set_yticklabels(tlbl, fontsize=8)
     ax.set_ylabel("Hz", fontsize=9)
+    ax.tick_params(axis="x", labelsize=8)
     if xlabel:
         ax.set_xlabel("Time frames", fontsize=9)
-    ax.tick_params(axis="x", labelsize=8)
     return im
 
 
@@ -596,19 +610,23 @@ def _render_figure(spec_a, spec_b, label_a, label_b, mode, n_fft, sr=44100):
     from matplotlib.backends.backend_agg import FigureCanvasAgg
 
     min_t = min(spec_a.shape[1], spec_b.shape[1])
-    sa = spec_a[::-1, :min_t]
-    sb = spec_b[::-1, :min_t]
 
+    # Resample to log-frequency and flip so low Hz is at bottom
+    sa = _to_log_freq(spec_a[:, :min_t])[::-1]
+    sb = _to_log_freq(spec_b[:, :min_t])[::-1]
+
+    tpos, tlbl = _log_freq_yticks(n_fft, sr=sr)
     CMAP = "inferno"
     DPI = 150
 
     if mode == "stacked":
+        vmin, vmax = _shared_vrange(sa, sb)
         fig = Figure(figsize=(14, 6), dpi=DPI, tight_layout=True)
         ax_a = fig.add_subplot(2, 1, 1)
         ax_b = fig.add_subplot(2, 1, 2)
-        _style_spec_ax(ax_a, sa, n_fft, CMAP, sr=sr)
+        _draw_spec(ax_a, sa, vmin, vmax, CMAP, tpos, tlbl)
         ax_a.set_title(label_a, fontsize=10)
-        im = _style_spec_ax(ax_b, sb, n_fft, CMAP, xlabel=True, sr=sr)
+        im = _draw_spec(ax_b, sb, vmin, vmax, CMAP, tpos, tlbl, xlabel=True)
         ax_b.set_title(label_b, fontsize=10)
         fig.colorbar(im, ax=[ax_a, ax_b], label="dB", fraction=0.02, pad=0.01)
 
@@ -617,37 +635,34 @@ def _render_figure(spec_a, spec_b, label_a, label_b, mode, n_fft, sr=44100):
         abs_max = float(np.percentile(np.abs(diff), 99.5)) + 1e-8
         fig = Figure(figsize=(14, 4), dpi=DPI, tight_layout=True)
         ax = fig.add_subplot(1, 1, 1)
-        n_freqs = sa.shape[0]
-        tpos, tlbl = _freq_yticks(n_fft, n_freqs, sr)
+        im = ax.imshow(diff, aspect="auto", cmap="RdBu_r", origin="upper",
+                       vmin=-abs_max, vmax=abs_max, interpolation="antialiased")
         ax.set_yticks(tpos)
         ax.set_yticklabels(tlbl, fontsize=8)
         ax.set_ylabel("Hz", fontsize=9)
         ax.set_xlabel("Time frames", fontsize=9)
-        im = ax.imshow(diff, aspect="auto", cmap="RdBu_r", origin="upper",
-                       vmin=-abs_max, vmax=abs_max, interpolation="antialiased")
         ax.set_title(f"[{label_a}] − [{label_b}]  ·  red = A louder  ·  blue = B louder", fontsize=10)
         fig.colorbar(im, ax=ax, label="ΔdB", fraction=0.02, pad=0.01)
 
     else:  # stacked + difference
+        vmin, vmax = _shared_vrange(sa, sb)
         diff = sa - sb
         abs_max = float(np.percentile(np.abs(diff), 99.5)) + 1e-8
         fig = Figure(figsize=(14, 9), dpi=DPI, tight_layout=True)
         ax_a = fig.add_subplot(3, 1, 1)
         ax_b = fig.add_subplot(3, 1, 2)
         ax_d = fig.add_subplot(3, 1, 3)
-        _style_spec_ax(ax_a, sa, n_fft, CMAP, sr=sr)
+        _draw_spec(ax_a, sa, vmin, vmax, CMAP, tpos, tlbl)
         ax_a.set_title(label_a, fontsize=10)
-        im_b = _style_spec_ax(ax_b, sb, n_fft, CMAP, sr=sr)
+        im_b = _draw_spec(ax_b, sb, vmin, vmax, CMAP, tpos, tlbl)
         ax_b.set_title(label_b, fontsize=10)
         fig.colorbar(im_b, ax=[ax_a, ax_b], label="dB", fraction=0.015, pad=0.01)
-        n_freqs = sa.shape[0]
-        tpos, tlbl = _freq_yticks(n_fft, n_freqs, sr)
+        im_d = ax_d.imshow(diff, aspect="auto", cmap="RdBu_r", origin="upper",
+                           vmin=-abs_max, vmax=abs_max, interpolation="antialiased")
         ax_d.set_yticks(tpos)
         ax_d.set_yticklabels(tlbl, fontsize=8)
         ax_d.set_ylabel("Hz", fontsize=9)
         ax_d.set_xlabel("Time frames", fontsize=9)
-        im_d = ax_d.imshow(diff, aspect="auto", cmap="RdBu_r", origin="upper",
-                           vmin=-abs_max, vmax=abs_max, interpolation="antialiased")
         ax_d.set_title(f"[{label_a}] − [{label_b}]", fontsize=10)
         fig.colorbar(im_d, ax=ax_d, label="ΔdB", fraction=0.015, pad=0.01)
 

--- a/nodes.py
+++ b/nodes.py
@@ -15,6 +15,131 @@ from comfy.utils import load_torch_file, ProgressBar
 device = mm.get_torch_device()
 offload_device = mm.unet_offload_device()
 
+# ---------------------------------------------------------------------------
+# Base config — all variable fields are overridden by infer_model_config()
+# ---------------------------------------------------------------------------
+_BASE_CONFIG = {
+    "stereo": True,
+    "num_bands": 60,
+    "dim_head": 64,
+    "heads": 8,
+    "attn_dropout": 0,
+    "ff_dropout": 0,
+    "flash_attn": True,
+    "dim_freqs_in": 1025,
+    "sample_rate": 44100,
+    "stft_n_fft": 2048,
+    "stft_hop_length": 441,
+    "stft_win_length": 2048,
+    "stft_normalized": False,
+    "mask_estimator_depth": 2,
+    "multi_stft_resolution_loss_weight": 1.0,
+    "multi_stft_resolutions_window_sizes": (4096, 2048, 1024, 512, 256),
+    "multi_stft_hop_size": 147,
+    "multi_stft_normalized": False,
+}
+
+# ---------------------------------------------------------------------------
+# HuggingFace model registry  (display_name -> (repo_id, filename))
+# ---------------------------------------------------------------------------
+MODEL_REGISTRY = {
+    # ── Vocals ──────────────────────────────────────────────────────────────
+    "Vocals · Kim fp16 ⭐ [Kijai]":          ("Kijai/MelBandRoFormer_comfy",                           "MelBandRoformer_fp16.safetensors"),
+    "Vocals · Kim fp32 [Kijai]":             ("Kijai/MelBandRoFormer_comfy",                           "MelBandRoformer_fp32.safetensors"),
+    "Vocals · Kim original [KimberleyJSN]":  ("KimberleyJSN/melbandroformer",                          "MelBandRoformer.ckpt"),
+    "Vocals · becruily":                     ("becruily/mel-band-roformer-vocals",                     "mel_band_roformer_vocals_becruily.ckpt"),
+    "Vocals small · pcunwa":                 ("pcunwa/Mel-Band-Roformer-small",                        "melband_roformer_small_v1.ckpt"),
+    # ── Instrumental ────────────────────────────────────────────────────────
+    "Instrumental · becruily":               ("becruily/mel-band-roformer-instrumental",               "mel_band_roformer_instrumental_becruily.ckpt"),
+    # ── Karaoke (lead-vocal removal) ────────────────────────────────────────
+    "Karaoke · aufr33/viperx ⭐":            ("jarredou/aufr33-viperx-karaoke-melroformer-model",      "mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"),
+    "Karaoke · becruily (2-stem)":           ("becruily/mel-band-roformer-karaoke",                   "mel_band_roformer_karaoke_becruily.ckpt"),
+    # ── Vocals + Instrumental 2-stem ────────────────────────────────────────
+    "Vocals+Instrumental 2-stem · becruily": ("becruily/mel-band-roformer-deux",                      "becruily_deux.ckpt"),
+    # ── Dereverb / Echo removal ─────────────────────────────────────────────
+    "Dereverb+Echo v2 · Sucial ⭐":          ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "dereverb_echo_mbr_v2_sdr_dry_13.4843.ckpt"),
+    "Dereverb+Echo fused · Sucial":          ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "dereverb_echo_mbr_fused_0.5_v2_0.25_big_0.25_super.ckpt"),
+    "Dereverb big reverb · Sucial":          ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "de_big_reverb_mbr_ep_362.ckpt"),
+    "Dereverb super-big reverb · Sucial":    ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "de_super_big_reverb_mbr_ep_346.ckpt"),
+    "Dereverb+Echo v1 · Sucial":             ("Sucial/Dereverb-Echo_Mel_Band_Roformer",                "dereverb-echo_mel_band_roformer_sdr_10.0169.ckpt"),
+    # ── Denoise ─────────────────────────────────────────────────────────────
+    "Denoise · aufr33 ⭐":                   ("poiqazwsx/melband-roformer-denoise",                   "denoise_mel_band_roformer_aufr33_sdr_27.9959.ckpt"),
+    "Denoise aggressive · aufr33":           ("poiqazwsx/melband-roformer-denoise",                   "denoise_mel_band_roformer_aufr33_aggr_sdr_27.9768.ckpt"),
+    # ── Aspiration (breath/mouth sounds) ────────────────────────────────────
+    "Aspiration · Sucial ⭐":                ("Sucial/Aspiration_Mel_Band_Roformer",                   "aspiration_mel_band_roformer_sdr_18.9845.ckpt"),
+    "Aspiration less-aggressive · Sucial":   ("Sucial/Aspiration_Mel_Band_Roformer",                   "aspiration_mel_band_roformer_less_aggr_sdr_18.1201.ckpt"),
+}
+
+_HF_PREFIX = "[HF] "
+
+
+def _hf_model_choices():
+    return [_HF_PREFIX + name for name in MODEL_REGISTRY]
+
+
+def _all_model_choices():
+    local = folder_paths.get_filename_list("MelBandRoFormer")
+    return local + _hf_model_choices()
+
+
+def infer_model_config(sd):
+    """Auto-detect architecture parameters from a state dict."""
+    config = dict(_BASE_CONFIG)
+
+    # dim: output size of the first band-split projection
+    config["dim"] = sd["band_split.to_features.0.1.weight"].shape[0]
+
+    # depth: number of (time-transformer, freq-transformer) blocks
+    config["depth"] = max(int(k.split('.')[1]) for k in sd if k.startswith('layers.')) + 1
+
+    # num_stems: number of mask estimators
+    config["num_stems"] = max(int(k.split('.')[1]) for k in sd if k.startswith('mask_estimators.')) + 1
+
+    # time_transformer_depth: layers inside the time transformer
+    # key format: layers.<block>.0.layers.<depth_idx>.<attn_or_ff>.*
+    time_keys = [k for k in sd if k.startswith('layers.0.0.layers.')]
+    if time_keys:
+        config["time_transformer_depth"] = max(int(k.split('.')[4]) for k in time_keys) + 1
+    else:
+        config["time_transformer_depth"] = 1
+
+    # freq_transformer_depth: layers inside the freq transformer
+    freq_keys = [k for k in sd if k.startswith('layers.0.1.layers.')]
+    if freq_keys:
+        config["freq_transformer_depth"] = max(int(k.split('.')[4]) for k in freq_keys) + 1
+    else:
+        config["freq_transformer_depth"] = 1
+
+    # mask_estimator_depth: number of hidden layers in the mask MLP
+    # key format: mask_estimators.0.to_freqs.0.0.<seq_idx>.weight
+    # Linear layers sit at even seq indices: 0, 2, 4, ...  → depth = max_even_idx // 2
+    mlp_keys = [k for k in sd if k.startswith('mask_estimators.0.to_freqs.0.0.') and k.endswith('.weight')]
+    if mlp_keys:
+        max_idx = max(int(k.split('.')[5]) for k in mlp_keys)
+        config["mask_estimator_depth"] = max_idx // 2
+    # else: keep _BASE_CONFIG default (2)
+
+    return config
+
+
+def download_hf_model(repo_id, filename):
+    """Download a model from HuggingFace into ComfyUI's diffusion_models folder."""
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError:
+        raise ImportError(
+            "huggingface_hub is required for auto-download. "
+            "Install with:  pip install huggingface_hub"
+        )
+    save_dir = folder_paths.get_folder_paths("MelBandRoFormer")[0]
+    save_path = os.path.join(save_dir, filename)
+    if not os.path.exists(save_path):
+        print(f"[MelBandRoFormer] Downloading {filename} from {repo_id} ...")
+        hf_hub_download(repo_id=repo_id, filename=filename, local_dir=save_dir)
+        print(f"[MelBandRoFormer] Saved to {save_path}")
+    return save_path
+
+
 def get_windowing_array(window_size, fade_size, device):
     fadein = torch.linspace(0, 1, fade_size)
     fadeout = torch.linspace(1, 0, fade_size)
@@ -23,51 +148,52 @@ def get_windowing_array(window_size, fade_size, device):
     window[:fade_size] *= fadein
     return window.to(device)
 
+
+# ---------------------------------------------------------------------------
+# Nodes
+# ---------------------------------------------------------------------------
+
 class MelBandRoFormerModelLoader:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "model_name": (folder_paths.get_filename_list("diffusion_models"), {"tooltip": "These models are loaded from the 'ComfyUI/models/diffusion_models' -folder",}),
+                "model_name": (
+                    _all_model_choices(),
+                    {
+                        "tooltip": (
+                            "Local files from ComfyUI/models/MelBandRoFormer/ come first. "
+                            "Entries starting with '[HF]' are downloaded automatically from HuggingFace "
+                            "into that folder on first use."
+                        ),
+                    },
+                ),
             },
         }
 
     RETURN_TYPES = ("MELROFORMERMODEL",)
-    RETURN_NAMES = ("model", )
+    RETURN_NAMES = ("model",)
     FUNCTION = "loadmodel"
     CATEGORY = "Mel-Band RoFormer"
 
     def loadmodel(self, model_name):
-        model_config = {
-                "dim": 384,
-                "depth": 6,
-                "stereo": True,
-                "num_stems": 1,
-                "time_transformer_depth": 1,
-                "freq_transformer_depth": 1,
-                "num_bands": 60,
-                "dim_head": 64,
-                "heads": 8,
-                "attn_dropout": 0,
-                "ff_dropout": 0,
-                "flash_attn": True,
-                "dim_freqs_in": 1025,
-                "sample_rate": 44100,  # needed for mel filter bank from librosa
-                "stft_n_fft": 2048,
-                "stft_hop_length": 441,
-                "stft_win_length": 2048,
-                "stft_normalized": False,
-                "mask_estimator_depth": 2,
-                "multi_stft_resolution_loss_weight": 1.0,
-                "multi_stft_resolutions_window_sizes": (4096, 2048, 1024, 512, 256),
-                "multi_stft_hop_size": 147,
-                "multi_stft_normalized": False,
-        }
-        model = MelBandRoformer(**model_config).eval()
-        model_path = folder_paths.get_full_path_or_raise("diffusion_models", model_name)
-        model.load_state_dict(load_torch_file(model_path), strict=True)
+        if model_name.startswith(_HF_PREFIX):
+            display_name = model_name[len(_HF_PREFIX):]
+            repo_id, filename = MODEL_REGISTRY[display_name]
+            model_path = download_hf_model(repo_id, filename)
+        else:
+            model_path = folder_paths.get_full_path_or_raise("MelBandRoFormer", model_name)
 
+        sd = load_torch_file(model_path)
+        config = infer_model_config(sd)
+        print(f"[MelBandRoFormer] Detected config: dim={config['dim']}, depth={config['depth']}, "
+              f"num_stems={config['num_stems']}, time_depth={config['time_transformer_depth']}, "
+              f"freq_depth={config['freq_transformer_depth']}")
+
+        model = MelBandRoformer(**config).eval()
+        model.load_state_dict(sd, strict=True)
         return (model,)
+
 
 class MelBandRoFormerSampler:
     @classmethod
@@ -76,95 +202,121 @@ class MelBandRoFormerSampler:
             "required": {
                 "model": ("MELROFORMERMODEL",),
                 "audio": ("AUDIO",),
+                "chunk_size": ("FLOAT", {
+                    "default": 8.0, "min": 1.0, "max": 30.0, "step": 0.5,
+                    "tooltip": "Chunk size in seconds. Smaller = less VRAM, larger = better quality on sustained sounds.",
+                }),
+                "overlap": ("INT", {
+                    "default": 2, "min": 2, "max": 8, "step": 1,
+                    "tooltip": "Overlap factor. Higher = smoother transitions but slower.",
+                }),
+                "fade_size": ("FLOAT", {
+                    "default": 0.1, "min": 0.01, "max": 0.5, "step": 0.01,
+                    "tooltip": "Crossfade ratio relative to chunk size. Higher = smoother blending.",
+                }),
+                "batch_size": ("INT", {
+                    "default": 1, "min": 1, "max": 16, "step": 1,
+                    "tooltip": "Number of chunks processed in parallel. Higher = faster but more VRAM. Start at 1 and increase until you hit OOM.",
+                }),
             },
         }
 
-    RETURN_TYPES = ("AUDIO","AUDIO",)
-    RETURN_NAMES = ("vocals", "instruments")
+    RETURN_TYPES = ("AUDIO", "AUDIO")
+    RETURN_NAMES = ("stem_1", "stem_2")
     FUNCTION = "process"
     CATEGORY = "Mel-Band RoFormer"
 
-    def process(self, model, audio):
-
+    def process(self, model, audio, chunk_size=8.0, overlap=2, fade_size=0.1, batch_size=1):
         audio_input = audio["waveform"]
         sample_rate = audio["sample_rate"]
 
         B, audio_channels, audio_length = audio_input.shape
-
         sr = 44100
 
         if audio_channels == 1:
-            # Convert mono to stereo by duplicating the channel
             audio_input = audio_input.repeat(1, 2, 1)
             audio_channels = 2
-            print("Converted mono input to stereo.")
+            print("[MelBandRoFormer] Converted mono input to stereo.")
 
         if sample_rate != sr:
-            print(f"Resampling input {sample_rate} to {sr}")
+            print(f"[MelBandRoFormer] Resampling {sample_rate} → {sr}")
             audio_input = TAF.resample(audio_input, orig_freq=sample_rate, new_freq=sr)
-        audio_input = original_audio = audio_input[0]
 
-        C = 352800
-        N = 2
-        step = C // N
-        fade_size = C // 10
+        audio_input = original_audio = audio_input[0]  # [channels, time]
+        audio_length = audio_input.shape[1]            # use resampled length for border logic
+
+        C = int(chunk_size * sr)
+        step = C // overlap
+        fade_samples = max(1, int(C * fade_size))
         border = C - step
 
         if audio_length > 2 * border and border > 0:
             audio_input = F.pad(audio_input, (border, border), mode='reflect')
 
-        windowing_array = get_windowing_array(C, fade_size, device)
-
+        windowing_array = get_windowing_array(C, fade_samples, device)
 
         audio_input = audio_input.to(device)
-        vocals = torch.zeros_like(audio_input, dtype=torch.float32).to(device)
-        counter = torch.zeros_like(audio_input, dtype=torch.float32).to(device)
-
+        num_stems = len(model.mask_estimators)
         total_length = audio_input.shape[1]
-        num_chunks = (total_length + step - 1) // step
+        chunk_starts = list(range(0, total_length, step))
+        num_chunks = len(chunk_starts)
+
+        # accumulators: [num_stems, channels, time]
+        acc = torch.zeros(num_stems, *audio_input.shape, dtype=torch.float32, device=device)
+        cnt = torch.zeros(num_stems, *audio_input.shape, dtype=torch.float32, device=device)
 
         model.to(device)
-
         comfy_pbar = ProgressBar(num_chunks)
 
-        for i in tqdm(range(0, total_length, step), desc="Processing chunks"):
-            part = audio_input[:, i:i + C]
-            length = part.shape[-1]
-            if length < C:
-                if length > C // 2 + 1:
-                    part = F.pad(input=part, pad=(0, C - length), mode='reflect')
-                else:
-                    part = F.pad(input=part, pad=(0, C - length, 0, 0), mode='constant', value=0)
+        with torch.no_grad():
+            for b_start in tqdm(range(0, num_chunks, batch_size), desc="Processing chunks"):
+                batch_starts = chunk_starts[b_start:b_start + batch_size]
 
-            x = model(part.unsqueeze(0))[0]
+                # build batch
+                parts, lengths = [], []
+                for i in batch_starts:
+                    part = audio_input[:, i:i + C]
+                    length = part.shape[-1]
+                    lengths.append(length)
+                    if length < C:
+                        pad_mode = 'reflect' if length > C // 2 + 1 else 'constant'
+                        part = F.pad(part, (0, C - length), mode=pad_mode)
+                    parts.append(part)
 
-            window = windowing_array.clone()
-            if i == 0:
-                window[:fade_size] = 1
-            elif i + C >= total_length:
-                window[-fade_size:] = 1
+                batch_in = torch.stack(parts, dim=0)          # [B, channels, C]
+                batch_out = model(batch_in)                    # [B, channels, C] or [B, stems, channels, C]
+                if num_stems == 1:
+                    batch_out = batch_out.unsqueeze(1)         # → [B, 1, channels, C]
 
-            vocals[..., i:i+length] += x[..., :length] * window[..., :length]
-            counter[..., i:i+length] += window[..., :length]
-            comfy_pbar.update(1)
+                # accumulate each chunk in the batch
+                for idx, (i, length) in enumerate(zip(batch_starts, lengths)):
+                    out = batch_out[idx]                       # [stems, channels, C]
+                    window = windowing_array.clone()
+                    if i == 0:
+                        window[:fade_samples] = 1
+                    if i + C >= total_length:
+                        window[-fade_samples:] = 1
+
+                    acc[..., i:i + length] += out[..., :length] * window[..., :length]
+                    cnt[..., i:i + length] += window[..., :length]
+
+                comfy_pbar.update(len(batch_starts))
 
         model.to(offload_device)
 
-        estimated_sources = vocals / counter
+        estimated = acc / cnt.clamp(min=1e-8)   # [num_stems, channels, time]
 
         if audio_length > 2 * border and border > 0:
-            estimated_sources = estimated_sources[..., border:-border]
+            estimated = estimated[..., border:-border]
 
-        vocals_out = {
-            "waveform": estimated_sources.unsqueeze(0).cpu(),
-            "sample_rate": sr,
-        }
-        instruments_out = {
-            "waveform": (original_audio.to(device) - estimated_sources).unsqueeze(0).cpu(),
-            "sample_rate": sr,
-        }
+        stem1 = estimated[0]
+        stem2 = estimated[1] if num_stems >= 2 else (original_audio.to(device) - stem1)
 
-        return (vocals_out, instruments_out)
+        def to_audio(t):
+            return {"waveform": t.unsqueeze(0).cpu(), "sample_rate": sr}
+
+        return (to_audio(stem1), to_audio(stem2))
+
 
 NODE_CLASS_MAPPINGS = {
     "MelBandRoFormerModelLoader": MelBandRoFormerModelLoader,

--- a/nodes.py
+++ b/nodes.py
@@ -781,15 +781,128 @@ class MelBandRoFormerModelLoaderLatest(MelBandRoFormerModelLoader):
     CATEGORY = "Mel-Band RoFormer"
 
 
+class MelBandRoFormerSampler4Stem(MelBandRoFormerSampler):
+    """4-stem variant — outputs stem_1 through stem_4.
+
+    Connects to any model loader just like the regular sampler.
+    For models with fewer than 4 stems, extra outputs are silence.
+    """
+
+    RETURN_TYPES = ("AUDIO", "AUDIO", "AUDIO", "AUDIO")
+    RETURN_NAMES = ("stem_1", "stem_2", "stem_3", "stem_4")
+    FUNCTION = "process4"
+    CATEGORY = "Mel-Band RoFormer"
+
+    def process4(self, model, audio, chunk_size=8.0, overlap=2, fade_size=0.1, batch_size=1):
+        stems = self._process_all(model, audio, chunk_size, overlap, fade_size, batch_size)
+        sr = stems[0]["sample_rate"]
+        length = stems[0]["waveform"].shape[-1]
+        channels = stems[0]["waveform"].shape[1]
+
+        def _get(idx):
+            if idx < len(stems):
+                return stems[idx]
+            return {"waveform": torch.zeros(1, channels, length), "sample_rate": sr}
+
+        return (_get(0), _get(1), _get(2), _get(3))
+
+    def _process_all(self, model, audio, chunk_size, overlap, fade_size, batch_size):
+        """Run inference and return a list of all stem AUDIO dicts."""
+        audio_input = audio["waveform"]
+        sample_rate = audio["sample_rate"]
+
+        B, audio_channels, audio_length = audio_input.shape
+        sr = 44100
+
+        if audio_channels == 1:
+            audio_input = audio_input.repeat(1, 2, 1)
+            audio_channels = 2
+
+        if sample_rate != sr:
+            audio_input = TAF.resample(audio_input, orig_freq=sample_rate, new_freq=sr)
+
+        audio_input = original_audio = audio_input[0]
+        audio_length = audio_input.shape[1]
+
+        C = int(chunk_size * sr)
+        step = C // overlap
+        fade_samples = max(1, int(C * fade_size))
+        border = C - step
+
+        if audio_length > 2 * border and border > 0:
+            audio_input = F.pad(audio_input, (border, border), mode='reflect')
+
+        windowing_array = get_windowing_array(C, fade_samples, device)
+        audio_input = audio_input.to(device)
+        num_stems = len(model.mask_estimators)
+        total_length = audio_input.shape[1]
+        chunk_starts = list(range(0, total_length, step))
+        num_chunks = len(chunk_starts)
+
+        acc = torch.zeros(num_stems, *audio_input.shape, dtype=torch.float32, device=device)
+        cnt = torch.zeros(num_stems, *audio_input.shape, dtype=torch.float32, device=device)
+
+        model.to(device)
+        comfy_pbar = ProgressBar(num_chunks)
+
+        with torch.no_grad():
+            for b_start in tqdm(range(0, num_chunks, batch_size), desc="Processing chunks"):
+                batch_starts = chunk_starts[b_start:b_start + batch_size]
+                parts, lengths = [], []
+                for i in batch_starts:
+                    part = audio_input[:, i:i + C]
+                    length = part.shape[-1]
+                    lengths.append(length)
+                    if length < C:
+                        pad_mode = 'reflect' if length > C // 2 + 1 else 'constant'
+                        part = F.pad(part, (0, C - length), mode=pad_mode)
+                    parts.append(part)
+
+                batch_in = torch.stack(parts, dim=0)
+                batch_out = model(batch_in)
+                if num_stems == 1:
+                    batch_out = batch_out.unsqueeze(1)
+
+                for idx, (i, length) in enumerate(zip(batch_starts, lengths)):
+                    out = batch_out[idx]
+                    window = windowing_array.clone()
+                    if i == 0:
+                        window[:fade_samples] = 1
+                    if i + C >= total_length:
+                        window[-fade_samples:] = 1
+                    acc[..., i:i + length] += out[..., :length] * window[..., :length]
+                    cnt[..., i:i + length] += window[..., :length]
+
+                comfy_pbar.update(len(batch_starts))
+
+        model.to(offload_device)
+        estimated = acc / cnt.clamp(min=1e-8)
+
+        if audio_length > 2 * border and border > 0:
+            estimated = estimated[..., border:-border]
+
+        def to_audio(t):
+            return {"waveform": t.unsqueeze(0).cpu(), "sample_rate": sr}
+
+        if num_stems == 1:
+            stem1 = estimated[0]
+            stem2 = original_audio.to(device) - stem1
+            return [to_audio(stem1), to_audio(stem2)]
+
+        return [to_audio(estimated[i]) for i in range(num_stems)]
+
+
 NODE_CLASS_MAPPINGS = {
     "MelBandRoFormerModelLoader": MelBandRoFormerModelLoader,
     "MelBandRoFormerModelLoaderLatest": MelBandRoFormerModelLoaderLatest,
     "MelBandRoFormerSampler": MelBandRoFormerSampler,
+    "MelBandRoFormerSampler4Stem": MelBandRoFormerSampler4Stem,
     "MelBandRoFormerSpectrogram": MelBandRoFormerSpectrogram,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     "MelBandRoFormerModelLoader": "Mel-Band RoFormer Model Loader",
     "MelBandRoFormerModelLoaderLatest": "Mel-Band RoFormer Model Loader (Latest)",
     "MelBandRoFormerSampler": "Mel-Band RoFormer Sampler",
+    "MelBandRoFormerSampler4Stem": "Mel-Band RoFormer Sampler (4-stem)",
     "MelBandRoFormerSpectrogram": "Mel-Band RoFormer Spectrogram",
 }

--- a/nodes.py
+++ b/nodes.py
@@ -545,6 +545,7 @@ _LOG_FREQ_BINS = 256  # output rows after log-frequency resampling
 def _db_spectrogram(wav, n_fft, hop_length):
     """Compute dB-magnitude spectrogram [freq, time], floored at _DB_FLOOR below peak."""
     import numpy as np
+    hop_length = min(hop_length, n_fft)   # torch.stft requires hop_length <= n_fft
     window = torch.hann_window(n_fft)
     stft = torch.stft(wav, n_fft=n_fft, hop_length=hop_length,
                       window=window, return_complex=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ComfyUI-MelBandRoFormer"
 description = "ComfyUI wrapper nodes for WanVideo"
 version = "1.0.2"
 license = {file = "LICENSE"}
-dependencies = ["rotary_embedding_torch", "einops"]
+dependencies = ["rotary_embedding_torch", "einops", "huggingface_hub", "BS-RoFormer"]
 
 [project.urls]
 Repository = "https://github.com/kijai/ComfyUI-MelBandRoFormer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ComfyUI-MelBandRoFormer"
-description = "ComfyUI wrapper nodes for WanVideo"
+description = "ComfyUI nodes for Mel-Band RoFormer and BS-RoFormer audio source separation — vocals, instruments, dereverb, denoise, and more"
 version = "1.0.2"
 license = {file = "LICENSE", text = "Apache-2.0"}
 dependencies = ["rotary_embedding_torch", "einops", "huggingface_hub", "BS-RoFormer"]
@@ -10,6 +10,6 @@ Repository = "https://github.com/kijai/ComfyUI-MelBandRoFormer"
 #  Used by Comfy Registry https://comfyregistry.org
 
 [tool.comfy]
-PublisherId = "kijai"
+PublisherId = "ethanfel"
 DisplayName = "ComfyUI-MelBandRoFormer"
 Icon = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ComfyUI-MelBandRoFormer"
 description = "ComfyUI wrapper nodes for WanVideo"
 version = "1.0.2"
-license = {file = "LICENSE"}
+license = {file = "LICENSE", text = "Apache-2.0"}
 dependencies = ["rotary_embedding_torch", "einops", "huggingface_hub", "BS-RoFormer"]
 
 [project.urls]

--- a/readme.md
+++ b/readme.md
@@ -53,17 +53,31 @@ To use a model you downloaded yourself, drop the `.ckpt` or `.safetensors` file 
 
 ## Nodes
 
-### Mel-Band RoFormer Model Loader
+### Mel-Band RoFormer Model Loader (Latest)
 
-Loads a model from your local folder or downloads it automatically from HuggingFace.
+Curated loader showing only the latest or best model from each series. Superseded versions are hidden. **Recommended starting point.**
 
 | Input | Description |
 |---|---|
-| `model_name` | Local filenames appear first. `[HF] …` entries auto-download on first use. |
+| `model_name` | Local files first, then curated `[HF]` entries. One winner per model family. |
+| `acknowledge_ckpt_risk` | Must be checked once before downloading `.ckpt` models. See [Security note](#security-note) below. |
 
-**Output:** a `MELROFORMERMODEL` — connect it to the Sampler node.
+---
 
-The loader automatically detects whether the checkpoint is a **Mel-Band RoFormer** or **BS-RoFormer** model and instantiates the correct architecture. No configuration needed.
+### Mel-Band RoFormer Model Loader
+
+Full loader — every model in the registry, including older versions. Use this when you need a specific older checkpoint or want to compare versions.
+
+| Input | Description |
+|---|---|
+| `model_name` | Local files first, then all `[HF]` entries. |
+| `acknowledge_ckpt_risk` | Must be checked once before downloading `.ckpt` models. |
+
+Both loaders automatically detect whether the checkpoint is **Mel-Band RoFormer** or **BS-RoFormer** and instantiate the correct architecture. No configuration needed. **Output:** `MELROFORMERMODEL` — connect to the Sampler.
+
+#### Security note
+
+Most models use the `.ckpt` format, which is based on Python pickle. Pickle can execute arbitrary code when a file is loaded. All models in this registry come from known, trusted authors on HuggingFace, so the practical risk is low — but you should be aware of it. Check `acknowledge_ckpt_risk` to confirm you understand. Your acknowledgment is saved to disk and will not be asked again.
 
 ---
 
@@ -73,7 +87,7 @@ Runs the separation and returns two audio streams.
 
 | Input | Default | Description |
 |---|---|---|
-| `model` | — | Connect from the Loader node. |
+| `model` | — | Connect from either Loader node. |
 | `audio` | — | Any ComfyUI `AUDIO` input. |
 | `chunk_size` | 8.0 s | Audio is processed in overlapping chunks. Larger = better quality on long sustained sounds, but more VRAM. Reduce if you get out-of-memory errors. |
 | `overlap` | 2 | How many chunks overlap. Higher = smoother crossfades between chunks, but slower. 2 is fine for most use cases; try 4 for very clean results. |
@@ -86,6 +100,30 @@ Runs the separation and returns two audio streams.
 | `stem_2` | The residual (original minus stem_1) for single-stem models, or the second stem for two-stem models (karaoke, aspiration). |
 
 > **4-stem models:** Only `stem_1` (vocals) and `stem_2` (drums) are output. Stems 3 and 4 (bass, other) are discarded with a console warning.
+
+---
+
+### Mel-Band RoFormer Spectrogram
+
+Visualizes and compares two audio streams as log-magnitude spectrograms. Connect the original audio and a separated stem to compare before/after side by side.
+
+| Input | Default | Description |
+|---|---|---|
+| `audio_a` | — | First audio stream (e.g. original). |
+| `audio_b` | — | Second audio stream (e.g. separated stem). |
+| `label_a` | `"A"` | Label shown on the first spectrogram panel. |
+| `label_b` | `"B"` | Label shown on the second spectrogram panel. |
+| `mode` | `stacked` | See modes below. |
+| `n_fft` | 2048 | FFT size. Larger = better frequency resolution, lower time resolution. |
+| `hop_length` | 512 | Hop size in samples. Smaller = better time resolution. |
+
+| Mode | Description |
+|---|---|
+| `stacked` | A on top, B below — same color scale for direct comparison. |
+| `difference` | Single panel showing A − B with a diverging colormap. Red = frequencies louder in A, blue = louder in B, white = identical. |
+| `stacked + difference` | All three panels: A, B, and the difference. |
+
+**Output:** `IMAGE` — plug directly into a Preview Image node.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,266 @@
-## ComfyUI node for [Mel-Band RoFormer for Music Source Separation](https://arxiv.org/abs/2310.01809)
+# ComfyUI-MelBandRoFormer
 
-Based on https://github.com/KimberleyJensen/Mel-Band-Roformer-Vocal-Model
+ComfyUI nodes for **Mel-Band RoFormer** — a state-of-the-art audio source separation model. Split audio into vocals and instruments, remove reverb, denoise recordings, isolate breath sounds, and more.
 
-Model:
+Based on the paper: [Mel-Band RoFormer for Music Source Separation](https://arxiv.org/abs/2310.01809) (Lu et al., 2023)
 
-https://huggingface.co/Kijai/MelBandRoFormer_comfy/tree/main
+![Workflow example](https://github.com/user-attachments/assets/05468504-b1b8-41da-8453-ae61e2c56a53)
 
-to `comfy_models\diffusion_models`
+---
 
-<img width="1969" height="726" alt="image" src="https://github.com/user-attachments/assets/05468504-b1b8-41da-8453-ae61e2c56a53" />
+## Installation
+
+### Via ComfyUI Manager (recommended)
+Search for **ComfyUI-MelBandRoFormer** in the Manager and install.
+
+### Manual
+```bash
+cd ComfyUI/custom_nodes
+git clone https://github.com/ethanfel/ComfyUI-MelBandRoFormer
+pip install huggingface_hub
+```
+
+### Models
+Models are stored in `ComfyUI/models/MelBandRoFormer/` (created automatically on first run).
+
+**You don't need to download anything manually.** In the loader node, any entry starting with `[HF]` downloads automatically from HuggingFace the first time you run it, then loads from disk on subsequent runs.
+
+To use a model you downloaded yourself, drop the `.ckpt` or `.safetensors` file into `ComfyUI/models/MelBandRoFormer/` and it will appear at the top of the dropdown.
+
+---
+
+## Which model should I pick?
+
+| I want to… | Recommended model |
+|---|---|
+| Extract vocals from a song | **Vocals · Kim FT v2 ⭐** |
+| Extract vocals with minimal instrument bleed | **Vocals · Kim FT v2 bleedless** |
+| Extract the instrumental / backing track | **Instrumental · GaboxR67 INSTV6 ⭐** |
+| Make a karaoke track (remove lead vocal) | **Karaoke · aufr33/viperx ⭐** |
+| Remove room reverb from a recording | **Dereverb · anvuew ⭐** |
+| Denoise a recording | **Denoise · aufr33 ⭐** |
+| Isolate breath / mouth sounds | **Aspiration · Sucial ⭐** |
+| Separate vocals + drums + bass + other | **4-stem large · Aname-Tommy** |
+| Low VRAM / fast preview | **Vocals · Kim fp16** |
+| Highest possible quality, have lots of VRAM | **Vocals big beta6 (dim=512) · pcunwa** |
+
+---
+
+## Nodes
+
+### Mel-Band RoFormer Model Loader
+
+Loads a model from your local folder or downloads it automatically from HuggingFace.
+
+| Input | Description |
+|---|---|
+| `model_name` | Local filenames appear first. `[HF] …` entries auto-download on first use. |
+
+**Output:** a `MELROFORMERMODEL` — connect it to the Sampler node.
+
+The loader automatically detects the model architecture from the checkpoint, so any model in the registry will load correctly regardless of its internal configuration.
+
+---
+
+### Mel-Band RoFormer Sampler
+
+Runs the separation and returns two audio streams.
+
+| Input | Default | Description |
+|---|---|---|
+| `model` | — | Connect from the Loader node. |
+| `audio` | — | Any ComfyUI `AUDIO` input. |
+| `chunk_size` | 8.0 s | Audio is processed in overlapping chunks. Larger = better quality on long sustained sounds, but more VRAM. Reduce if you get out-of-memory errors. |
+| `overlap` | 2 | How many chunks overlap. Higher = smoother crossfades between chunks, but slower. 2 is fine for most use cases; try 4 for very clean results. |
+| `fade_size` | 0.1 | Fraction of each chunk used for crossfading (0.01–0.5). Higher = smoother blending at chunk boundaries. |
+| `batch_size` | 1 | Process N chunks simultaneously. Higher = faster, but uses more VRAM. Start at 1 and increase until you hit an out-of-memory error. |
+
+| Output | Description |
+|---|---|
+| `stem_1` | The primary separated audio (e.g. vocals for a vocal model, dry signal for a dereverb model). |
+| `stem_2` | The residual (original minus stem_1) for single-stem models, or the second stem for two-stem models (karaoke, aspiration). |
+
+> **4-stem models:** Only `stem_1` (vocals) and `stem_2` (drums) are output. Stems 3 and 4 (bass, other) are discarded with a console warning.
+
+---
+
+## Model Catalog
+
+### Vocals
+
+Extract the vocal track from a song.
+
+| Model | SDR | Notes | Quality |
+|---|---|---|---|
+| **Vocals · Kim FT v2** | — | Finetuned version of the Kim model, best general-purpose vocal separator | ⭐⭐⭐⭐⭐ Best overall |
+| **Vocals · Kim FT v2 bleedless** | — | Same as FT v2 but tuned to reduce instrument bleed into the vocal output | ⭐⭐⭐⭐⭐ Best for clean isolation |
+| **Vocals · Kim FT v1** | — | Earlier finetune, slightly less refined than v2 | ⭐⭐⭐⭐ |
+| **Vocals · Kim fp16** | 10.98 | Original Kim model, fp16 precision — fastest, lowest VRAM | ⭐⭐⭐⭐ Best for speed/VRAM |
+| **Vocals · Kim fp32** | 10.98 | Same, full precision — marginally higher quality at double the VRAM | ⭐⭐⭐⭐ |
+| **Vocals · Kim original** | 10.98 | Original checkpoint from KimberleyJSN | ⭐⭐⭐⭐ |
+| **Vocals · becruily** | — | Community-trained alternative | ⭐⭐⭐ |
+| **Vocals · GaboxR67 fv7** | — | Community model, dim=256/depth=12 — deep but narrow | ⭐⭐⭐ |
+| **Vocals · GaboxR67 fv6** | — | Previous iteration of the fv series | ⭐⭐⭐ |
+| **Vocals small · pcunwa** | — | Smaller/faster model, good for previewing | ⭐⭐ Fast |
+| **Vocals big beta6 (dim=512)** | — | Wider architecture than standard (dim=512 vs 384) — potentially higher quality at the cost of more VRAM | ⭐⭐⭐⭐⭐ Best quality, high VRAM |
+| **Vocals big beta6x** | — | Experimental variant of beta6 | ⭐⭐⭐⭐ |
+| **Vocals big beta7** | — | Latest big series, depth=8 | ⭐⭐⭐⭐ |
+
+---
+
+### Instrumental
+
+Extract the backing track / remove vocals.
+
+| Model | SDR | Notes | Quality |
+|---|---|---|---|
+| **Instrumental · GaboxR67 INSTV6** | — | Latest and most refined instrumental model from GaboxR67 | ⭐⭐⭐⭐⭐ Best overall |
+| **Instrumental · GaboxR67 Fv9** | — | F-series, one step below INSTV6 | ⭐⭐⭐⭐ |
+| **Instrumental · GaboxR67 Fv8** | — | F-series v8 | ⭐⭐⭐⭐ |
+| **Instrumental v2 (depth-12) · pcunwa** | — | Deeper model (depth=12), potentially captures more complex patterns | ⭐⭐⭐⭐ Best depth |
+| **Instrumental v1 · pcunwa** | — | Standard depth baseline | ⭐⭐⭐ |
+| **Instrumental · becruily** | — | Community alternative | ⭐⭐⭐ |
+
+---
+
+### Karaoke
+
+Remove the lead vocal while keeping backing vocals and instruments.
+
+| Model | SDR | Notes | Quality |
+|---|---|---|---|
+| **Karaoke · aufr33/viperx** | 10.20 | The standard karaoke model, widely used and validated | ⭐⭐⭐⭐⭐ Best overall |
+| **Karaoke · becruily (2-stem)** | — | 2-stem model: stem_1 = vocals, stem_2 = karaoke directly | ⭐⭐⭐⭐ |
+| **Karaoke · GaboxR67 V1** | — | Community alternative | ⭐⭐⭐ |
+
+---
+
+### Vocals + Instrumental (2-stem direct)
+
+Models that output both vocals and instrumental simultaneously rather than computing one as the residual of the other.
+
+| Model | Vocals SDR | Instrumental SDR | Quality |
+|---|---|---|---|
+| **Vocals+Instrumental 2-stem · becruily** | 11.37 | 17.55 | ⭐⭐⭐⭐⭐ Best dual-output |
+
+`stem_1` = vocals, `stem_2` = instrumental.
+
+---
+
+### 4-Stem Separation
+
+Separates audio into vocals, drums, bass, and other simultaneously.
+
+> **Note:** The current sampler node only outputs `stem_1` (vocals) and `stem_2` (drums). Bass and other are discarded. Full 4-stem support is planned.
+
+| Model | Size | Notes | Quality |
+|---|---|---|---|
+| **4-stem large · Aname-Tommy** | 3.76 GB | Good balance of quality and VRAM usage | ⭐⭐⭐⭐ Recommended |
+| **4-stem XL · Aname-Tommy** | 6.41 GB | Higher capacity — requires significant VRAM | ⭐⭐⭐⭐⭐ Best quality |
+
+MelBandRoFormer's mel-band scheme has limited low-frequency resolution, so bass separation is less precise than for vocals or drums. Consider [BS-RoFormer](https://github.com/ZFTurbo/Music-Source-Separation-Training) for bass-critical work.
+
+---
+
+### Dereverb / Echo Removal
+
+Remove room reverb and echo from recordings. Useful for cleaning up vocal takes, speech recordings, and field recordings.
+
+| Model | SDR | Notes | Quality |
+|---|---|---|---|
+| **Dereverb mono-optimized · anvuew** | 20.40 | Highest SDR — optimized for mono or centered sources | ⭐⭐⭐⭐⭐ Best SDR |
+| **Dereverb · anvuew** | 19.17 | General-purpose dereverb, best for stereo material | ⭐⭐⭐⭐⭐ Best overall |
+| **Dereverb less-aggressive · anvuew** | 18.80 | Same model, less processing — good when you want to preserve some room feel | ⭐⭐⭐⭐ |
+| **Dereverb+Echo v2 · Sucial** | 13.48 | Trained on singing voice data (opencpop/GTSinger) | ⭐⭐⭐ Good for singing |
+| **Dereverb+Echo fused · Sucial** | — | Blend of v2, big, and super-big Sucial models | ⭐⭐⭐ |
+| **Dereverb big reverb · Sucial** | — | Tuned for large reverberant spaces | ⭐⭐⭐ Large rooms |
+| **Dereverb super-big reverb · Sucial** | — | Tuned for very large reverberant spaces (halls, cathedrals) | ⭐⭐⭐ Halls |
+| **Dereverb+Echo v1 · Sucial** | 10.02 | Original Sucial model | ⭐⭐ |
+
+`stem_1` = dry (cleaned) signal. `stem_2` = extracted reverb/echo tail.
+
+---
+
+### Denoise
+
+Remove background noise from recordings.
+
+| Model | SDR | Notes | Quality |
+|---|---|---|---|
+| **Denoise · aufr33** | 27.99 | Best general-purpose denoiser — strong SDR | ⭐⭐⭐⭐⭐ Best overall |
+| **Denoise aggressive · aufr33** | 27.97 | More aggressive noise removal — may remove some wanted signal | ⭐⭐⭐⭐ For heavy noise |
+
+`stem_1` = clean signal. `stem_2` = extracted noise.
+
+---
+
+### Aspiration / Breath Sounds
+
+Isolate or remove breath sounds, aspiration noise, and mouth sounds from vocal recordings.
+
+| Model | SDR | Notes | Quality |
+|---|---|---|---|
+| **Aspiration · Sucial** | 18.98 | Strongest aspiration removal | ⭐⭐⭐⭐⭐ Best overall |
+| **Aspiration less-aggressive · Sucial** | 18.12 | Preserves more of the vocal character | ⭐⭐⭐⭐ More natural |
+
+`stem_1` = dry vocal (aspiration removed). `stem_2` = isolated aspiration/breath signal.
+
+> **Tip for isolating specific mouth sounds (e.g. lip smacks, lollipop sounds):** These sounds overlap spectrally with breath and aspiration. Run the Aspiration model first. The resulting `stem_2` will contain the isolated breath-and-mouth-noise component, which you can then process further with EQ or gating.
+
+---
+
+## Tips
+
+### VRAM & Speed
+
+| Setting | Effect |
+|---|---|
+| ↓ `chunk_size` | Less VRAM, slightly lower quality on long sustained notes |
+| ↑ `batch_size` | Faster processing, more VRAM. Increase until you hit OOM, then step back by 1. |
+| ↑ `overlap` | Smoother results at chunk boundaries, slower. 2 is fine; 4 for critical work. |
+
+**Starting points by VRAM:**
+- 4 GB → `chunk_size=4`, `batch_size=1`
+- 8 GB → `chunk_size=8`, `batch_size=2`
+- 16 GB → `chunk_size=8`, `batch_size=4`
+- 24 GB+ → `chunk_size=12`, `batch_size=8`
+
+### Chaining Models
+
+You can connect the output of one Sampler into a second Sampler for two-stage processing:
+
+- **Vocal cleanup:** Vocal model → Dereverb model on `stem_1`
+- **Clean instrument isolation:** Instrumental model → Denoise model on `stem_1`
+- **Mouth sound isolation:** Vocal model → Aspiration model on `stem_1` → `stem_2` contains mouth sounds
+
+### Audio Format
+
+- Mono inputs are automatically duplicated to stereo before processing.
+- Audio at sample rates other than 44100 Hz is automatically resampled.
+- Output is always at 44100 Hz.
+
+---
+
+## Credits & Attribution
+
+### Paper
+- **Mel-Band RoFormer** — Lu et al. (2023): [arxiv.org/abs/2310.01809](https://arxiv.org/abs/2310.01809)
+
+### Original Implementation & Models
+- **[KimberleyJensen](https://github.com/KimberleyJensen/Mel-Band-Roformer-Vocal-Model)** — original vocal model implementation and checkpoint
+- **[Kijai](https://huggingface.co/Kijai/MelBandRoFormer_comfy)** — ComfyUI-optimized safetensors (fp16/fp32)
+- **[ZFTurbo](https://github.com/ZFTurbo/Music-Source-Separation-Training)** — training framework used by most models in this registry
+
+### Model Authors
+| Author | Models |
+|---|---|
+| **[pcunwa](https://huggingface.co/pcunwa)** | Kim FT finetuned variants, Inst v1/v2, big beta series |
+| **[aufr33](https://huggingface.co/poiqazwsx/melband-roformer-denoise) & [viperx](https://huggingface.co/jarredou/aufr33-viperx-karaoke-melroformer-model)** | Karaoke model, denoise models |
+| **[Sucial](https://huggingface.co/Sucial)** | Dereverb+Echo models, Aspiration models |
+| **[becruily](https://huggingface.co/becruily)** | Vocals, instrumental, karaoke, deux (2-stem) |
+| **[anvuew](https://huggingface.co/anvuew/dereverb_mel_band_roformer)** | High-SDR dereverb models |
+| **[GaboxR67](https://huggingface.co/GaboxR67/MelBandRoformers)** | Extensive community vocal, instrumental, karaoke variants |
+| **[Aname-Tommy](https://huggingface.co/Aname-Tommy/melbandroformer4stems)** | 4-stem large and XL models |
+
+### This Node
+Originally forked from [kijai/ComfyUI-MelRoFormer](https://github.com/kijai/ComfyUI-MelRoFormer). Extended with multi-model support, HuggingFace auto-download, architecture auto-detection, batched inference, and multi-stem output by [ethanfel](https://github.com/ethanfel).

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,12 @@
 # ComfyUI-MelBandRoFormer
 
-ComfyUI nodes for **Mel-Band RoFormer** — a state-of-the-art audio source separation model. Split audio into vocals and instruments, remove reverb, denoise recordings, isolate breath sounds, and more.
+ComfyUI nodes for **Mel-Band RoFormer** and **BS-RoFormer** — state-of-the-art audio source separation models. Split audio into vocals and instruments, remove reverb, denoise recordings, isolate breath sounds, and more.
 
-Based on the paper: [Mel-Band RoFormer for Music Source Separation](https://arxiv.org/abs/2310.01809) (Lu et al., 2023)
+Both architectures are supported from a single loader node — the checkpoint is automatically detected.
+
+Based on the papers:
+- [Mel-Band RoFormer for Music Source Separation](https://arxiv.org/abs/2310.01809) (Lu et al., 2023)
+- [Music Source Separation with Band-Split RoFormer](https://arxiv.org/abs/2309.02612) (Yu et al., 2023)
 
 ![Workflow example](https://github.com/user-attachments/assets/05468504-b1b8-41da-8453-ae61e2c56a53)
 
@@ -35,9 +39,10 @@ To use a model you downloaded yourself, drop the `.ckpt` or `.safetensors` file 
 |---|---|
 | Extract vocals from a song | **Vocals · Kim FT v2 ⭐** |
 | Extract vocals with minimal instrument bleed | **Vocals · Kim FT v2 bleedless** |
+| Best vocal quality, BS-RoFormer architecture | **[BS] Vocals revive v3e · pcunwa** |
 | Extract the instrumental / backing track | **Instrumental · GaboxR67 INSTV6 ⭐** |
 | Make a karaoke track (remove lead vocal) | **Karaoke · aufr33/viperx ⭐** |
-| Remove room reverb from a recording | **Dereverb · anvuew ⭐** |
+| Remove room reverb from a recording | **[BS] Dereverb · anvuew (SDR 22.51)** |
 | Denoise a recording | **Denoise · aufr33 ⭐** |
 | Isolate breath / mouth sounds | **Aspiration · Sucial ⭐** |
 | Separate vocals + drums + bass + other | **4-stem large · Aname-Tommy** |
@@ -58,7 +63,7 @@ Loads a model from your local folder or downloads it automatically from HuggingF
 
 **Output:** a `MELROFORMERMODEL` — connect it to the Sampler node.
 
-The loader automatically detects the model architecture from the checkpoint, so any model in the registry will load correctly regardless of its internal configuration.
+The loader automatically detects whether the checkpoint is a **Mel-Band RoFormer** or **BS-RoFormer** model and instantiates the correct architecture. No configuration needed.
 
 ---
 
@@ -105,6 +110,20 @@ Extract the vocal track from a song.
 | **Vocals big beta6 (dim=512)** | — | Wider architecture than standard (dim=512 vs 384) — potentially higher quality at the cost of more VRAM | ⭐⭐⭐⭐⭐ Best quality, high VRAM |
 | **Vocals big beta6x** | — | Experimental variant of beta6 | ⭐⭐⭐⭐ |
 | **Vocals big beta7** | — | Latest big series, depth=8 | ⭐⭐⭐⭐ |
+
+---
+
+### BS-RoFormer Vocals
+
+BS-RoFormer uses non-overlapping linear frequency bands instead of overlapping mel bands. It is slightly weaker than the best MelBandRoFormer models on vocals alone, but handles bass frequencies more precisely.
+
+| Model | Notes | Quality |
+|---|---|---|
+| **[BS] Vocals revive v3e · pcunwa** | Latest and best of the Revive series | ⭐⭐⭐⭐⭐ Best BS-RoFormer vocal |
+| **[BS] Vocals revive v2 · pcunwa** | Second iteration | ⭐⭐⭐⭐ |
+| **[BS] Vocals revive v1 · pcunwa** | Original Revive checkpoint | ⭐⭐⭐ |
+
+`stem_1` = vocals. `stem_2` = residual (instrumental).
 
 ---
 
@@ -168,8 +187,9 @@ Remove room reverb and echo from recordings. Useful for cleaning up vocal takes,
 
 | Model | SDR | Notes | Quality |
 |---|---|---|---|
-| **Dereverb mono-optimized · anvuew** | 20.40 | Highest SDR — optimized for mono or centered sources | ⭐⭐⭐⭐⭐ Best SDR |
-| **Dereverb · anvuew** | 19.17 | General-purpose dereverb, best for stereo material | ⭐⭐⭐⭐⭐ Best overall |
+| **[BS] Dereverb · anvuew** | 22.51 | BS-RoFormer model — highest SDR of any dereverb model here | ⭐⭐⭐⭐⭐ Best overall |
+| **Dereverb mono-optimized · anvuew** | 20.40 | MelBand — optimized for mono or centered sources | ⭐⭐⭐⭐⭐ Best MelBand SDR |
+| **Dereverb · anvuew** | 19.17 | MelBand — general-purpose, best for stereo material | ⭐⭐⭐⭐⭐ |
 | **Dereverb less-aggressive · anvuew** | 18.80 | Same model, less processing — good when you want to preserve some room feel | ⭐⭐⭐⭐ |
 | **Dereverb+Echo v2 · Sucial** | 13.48 | Trained on singing voice data (opencpop/GTSinger) | ⭐⭐⭐ Good for singing |
 | **Dereverb+Echo fused · Sucial** | — | Blend of v2, big, and super-big Sucial models | ⭐⭐⭐ |
@@ -243,22 +263,24 @@ You can connect the output of one Sampler into a second Sampler for two-stage pr
 
 ## Credits & Attribution
 
-### Paper
+### Papers
 - **Mel-Band RoFormer** — Lu et al. (2023): [arxiv.org/abs/2310.01809](https://arxiv.org/abs/2310.01809)
+- **BS-RoFormer** — Yu et al. (2023): [arxiv.org/abs/2309.02612](https://arxiv.org/abs/2309.02612)
 
 ### Original Implementation & Models
 - **[KimberleyJensen](https://github.com/KimberleyJensen/Mel-Band-Roformer-Vocal-Model)** — original vocal model implementation and checkpoint
 - **[Kijai](https://huggingface.co/Kijai/MelBandRoFormer_comfy)** — ComfyUI-optimized safetensors (fp16/fp32)
 - **[ZFTurbo](https://github.com/ZFTurbo/Music-Source-Separation-Training)** — training framework used by most models in this registry
+- **[lucidrains/BS-RoFormer](https://github.com/lucidrains/BS-RoFormer)** — BS-RoFormer PyPI package used for BS-RoFormer inference
 
 ### Model Authors
 | Author | Models |
 |---|---|
-| **[pcunwa](https://huggingface.co/pcunwa)** | Kim FT finetuned variants, Inst v1/v2, big beta series |
+| **[pcunwa](https://huggingface.co/pcunwa)** | Kim FT finetuned variants, Inst v1/v2, big beta series, BS-RoFormer Revive series |
 | **[aufr33](https://huggingface.co/poiqazwsx/melband-roformer-denoise) & [viperx](https://huggingface.co/jarredou/aufr33-viperx-karaoke-melroformer-model)** | Karaoke model, denoise models |
 | **[Sucial](https://huggingface.co/Sucial)** | Dereverb+Echo models, Aspiration models |
 | **[becruily](https://huggingface.co/becruily)** | Vocals, instrumental, karaoke, deux (2-stem) |
-| **[anvuew](https://huggingface.co/anvuew/dereverb_mel_band_roformer)** | High-SDR dereverb models |
+| **[anvuew](https://huggingface.co/anvuew)** | High-SDR MelBand dereverb models + BS-RoFormer dereverb (SDR 22.51) |
 | **[GaboxR67](https://huggingface.co/GaboxR67/MelBandRoformers)** | Extensive community vocal, instrumental, karaoke variants |
 | **[Aname-Tommy](https://huggingface.co/Aname-Tommy/melbandroformer4stems)** | 4-stem large and XL models |
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 rotary_embedding_torch
 einops
+huggingface_hub
+BS-RoFormer

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ rotary_embedding_torch
 einops
 huggingface_hub
 BS-RoFormer
+pyloudnorm


### PR DESCRIPTION
## Summary

Major extension of the original node with full backwards compatibility.

### New features

- **47-model registry** — vocal separators, instrumentals, karaoke, 2-stem, 4-stem, dereverb, denoise, aspiration, with HuggingFace auto-download on first use
- **BS-RoFormer support** — both architectures load from a single Loader node; architecture is auto-detected from the checkpoint (no config files needed)
- **Inference improvements** — batched chunk processing, proper overlap-add windowing, mono→stereo conversion, auto-resampling to 44100 Hz
- **Model Loader (Latest)** — curated node showing only the best/current model per series; full Loader still available for power users
- **Spectrogram comparison node** — log-frequency, dB-scaled, shared color range across panels; modes: stacked / difference (diverging ΔdB) / stacked + difference
- **.ckpt pickle risk acknowledgment** — one-time prompt before auto-downloading `.ckpt` files, saved to disk
- **Clean dropdown** — registry models hidden from local file list after download (no duplicates); cache/metadata files filtered out

### Nodes

| Node | Description |
|---|---|
| Mel-Band RoFormer Model Loader | Full model list |
| Mel-Band RoFormer Model Loader (Latest) | Curated latest-only list |
| Mel-Band RoFormer Sampler | Separation with chunk/overlap/fade/batch controls |
| Mel-Band RoFormer Spectrogram | Before/after visual comparison |

### Dependencies added
- `huggingface_hub` — auto-download
- `BS-RoFormer` — BS-RoFormer inference (lucidrains)

## Test plan

- [ ] Load a MelBandRoformer `.ckpt` model via HF auto-download
- [ ] Load a BSRoformer `.ckpt` model — verify architecture auto-detected
- [ ] Load a `.safetensors` model — verify no ckpt warning shown
- [ ] Run Sampler on mono input, stereo input, non-44100 Hz input
- [ ] Run Spectrogram node in all three modes
- [ ] Verify Model Loader (Latest) shows fewer entries than full Loader
- [ ] Verify manually dropped `.ckpt` files appear at top of list

🤖 Generated with [Claude Code](https://claude.com/claude-code)